### PR TITLE
feat(frontend): add signup page matching login style

### DIFF
--- a/frontend/src/app/signup/page.tsx
+++ b/frontend/src/app/signup/page.tsx
@@ -1,10 +1,9 @@
 import Image from "next/image"
-import { LoginForm } from "@/components/auth/login-form"
+import { SignUpForm } from "@/components/auth/signup-form"
 
-export default function LoginPage() {
+export default function SignUpPage() {
   return (
     <div className="min-h-screen flex bg-background">
-      {/* Left: Cinema Image Panel */}
       <div className="hidden lg:flex lg:w-1/2 xl:w-3/5 relative overflow-hidden">
         <Image
           src="/movie-login.png"
@@ -18,19 +17,17 @@ export default function LoginPage() {
         <div className="absolute inset-0 flex flex-col justify-end p-12 xl:p-16">
           <blockquote className="max-w-lg">
             <p className="text-lg xl:text-xl text-card/90 leading-relaxed italic font-serif text-white">
-              {'"A good film is when the price of the dinner, the theatre admission and the babysitter were all worth it."'}
+              {'"Cinema is a matter of what\'s in the frame and what\'s out."'}
             </p>
             <footer className="mt-3 text-sm text-card/70 tracking-wide">
-              {"— Alfred Hitchcock"}
+              {"— Martin Scorsese"}
             </footer>
           </blockquote>
         </div>
       </div>
 
-      {/* Right: Login Form Panel */}
       <div className="flex-1 flex flex-col justify-center px-6 py-12 sm:px-12 lg:px-16 xl:px-20">
         <div className="mx-auto w-full max-w-sm">
-          {/* Logo */}
           <div className="flex items-center gap-3 mb-12">
             <div className="flex items-center justify-center w-10 h-10 rounded-xl bg-primary">
               <svg className="h-5 w-5 text-primary-foreground" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" aria-hidden="true">
@@ -42,24 +39,21 @@ export default function LoginPage() {
             </span>
           </div>
 
-          {/* Heading */}
           <div className="mb-8">
             <h1 className="text-3xl font-serif font-semibold tracking-tight text-foreground text-balance">
-              Welcome back
+              Create your account
             </h1>
             <p className="mt-2 text-muted-foreground leading-relaxed">
-              Sign in to book your next movie night
+              Join Go4Movies and start booking your favorite shows
             </p>
           </div>
 
-          {/* Form */}
-          <LoginForm />
+          <SignUpForm />
 
-          {/* Footer */}
           <p className="mt-8 text-center text-sm text-muted-foreground">
-            {"Don't have an account? "}
-            <a href="/signup" className="text-primary hover:opacity-80 font-medium transition-opacity">
-              Create one
+            {"Already have an account? "}
+            <a href="/login" className="text-primary hover:opacity-80 font-medium transition-opacity">
+              Sign in
             </a>
           </p>
         </div>

--- a/frontend/src/components/auth/login-form.tsx
+++ b/frontend/src/components/auth/login-form.tsx
@@ -1,18 +1,39 @@
 "use client"
 
 import { useState } from "react"
+import { useRouter } from "next/navigation"
+import { loginUser } from "@/lib/api"
 
 export function LoginForm() {
+  const router = useRouter()
   const [showPassword, setShowPassword] = useState<boolean>(false)
+  const [email, setEmail] = useState<string>("")
+  const [password, setPassword] = useState<string>("")
+  const [errorMessage, setErrorMessage] = useState<string>("")
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false)
 
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
-    const form = e.currentTarget
-    const email = (form.elements.namedItem("email") as HTMLInputElement).value
-    const password = (form.elements.namedItem("password") as HTMLInputElement).value
-    
-  } 
-  
+    setErrorMessage("")
+
+    if (!email.trim() || !password) {
+      setErrorMessage("Email and password are required")
+      return
+    }
+
+    try {
+      setIsSubmitting(true)
+      await loginUser({
+        email: email.trim(),
+        password,
+      })
+      router.push("/")
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : "Failed to login")
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-5">
@@ -35,9 +56,13 @@ export function LoginForm() {
           </svg>
           <input
             id="email"
+            name="email"
             type="email"
             placeholder="you@example.com"
             className="w-full h-12 pl-10 pr-4 rounded-xl border border-border bg-card text-foreground text-sm placeholder:text-muted-foreground/60 outline-none focus:ring-2 focus:ring-ring/40 focus:border-primary transition-all"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            required
           />
         </div>
       </div>
@@ -61,9 +86,13 @@ export function LoginForm() {
           </svg>
           <input
             id="password"
+            name="password"
             type={showPassword ? "text" : "password"}
             placeholder="Enter your password"
             className="w-full h-12 pl-10 pr-10 rounded-xl border border-border bg-card text-foreground text-sm placeholder:text-muted-foreground/60 outline-none focus:ring-2 focus:ring-ring/40 focus:border-primary transition-all"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            required
           />
           <button
             type="button"
@@ -103,10 +132,17 @@ export function LoginForm() {
       {/* Submit */}
       <button
         type="submit"
+        disabled={isSubmitting}
         className="h-12 rounded-xl bg-primary text-primary-foreground text-sm font-medium tracking-wide shadow-md shadow-primary/20 hover:shadow-lg hover:shadow-primary/30 hover:brightness-110 active:scale-[0.98] transition-all mt-1"
       >
-        Sign In
+        {isSubmitting ? "Signing in..." : "Sign In"}
       </button>
+
+      {errorMessage ? (
+        <p className="text-sm text-destructive" role="alert" aria-live="polite">
+          {errorMessage}
+        </p>
+      ) : null}
 
       {/* Divider */}
       <div className="relative flex items-center justify-center my-1">

--- a/frontend/src/components/auth/signup-form.tsx
+++ b/frontend/src/components/auth/signup-form.tsx
@@ -1,0 +1,221 @@
+"use client"
+
+import { useState } from "react"
+
+export function SignUpForm() {
+  const [showPassword, setShowPassword] = useState<boolean>(false)
+  const [showConfirmPassword, setShowConfirmPassword] = useState<boolean>(false)
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    const form = e.currentTarget
+    const fullName = (form.elements.namedItem("fullName") as HTMLInputElement).value
+    const email = (form.elements.namedItem("email") as HTMLInputElement).value
+    const password = (form.elements.namedItem("password") as HTMLInputElement).value
+    const confirmPassword = (form.elements.namedItem("confirmPassword") as HTMLInputElement).value
+
+    void fullName
+    void email
+    void password
+    void confirmPassword
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-5">
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="fullName" className="text-sm font-medium text-foreground">
+          Full name
+        </label>
+        <div className="relative">
+          <svg
+            className="absolute left-3.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+            aria-hidden="true"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M17.982 18.725A7.488 7.488 0 0 0 12 15.75a7.488 7.488 0 0 0-5.982 2.975m11.963 0a9 9 0 1 0-11.963 0m11.963 0A8.966 8.966 0 0 1 12 21a8.966 8.966 0 0 1-5.982-2.275M15 9.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+          </svg>
+          <input
+            id="fullName"
+            name="fullName"
+            type="text"
+            placeholder="John Doe"
+            className="w-full h-12 pl-10 pr-4 rounded-xl border border-border bg-card text-foreground text-sm placeholder:text-muted-foreground/60 outline-none focus:ring-2 focus:ring-ring/40 focus:border-primary transition-all"
+            required
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="email" className="text-sm font-medium text-foreground">
+          Email
+        </label>
+        <div className="relative">
+          <svg
+            className="absolute left-3.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+            aria-hidden="true"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25m19.5 0v.243a2.25 2.25 0 0 1-1.07 1.916l-7.5 4.615a2.25 2.25 0 0 1-2.36 0L3.32 8.91a2.25 2.25 0 0 1-1.07-1.916V6.75" />
+          </svg>
+          <input
+            id="email"
+            name="email"
+            type="email"
+            placeholder="you@example.com"
+            className="w-full h-12 pl-10 pr-4 rounded-xl border border-border bg-card text-foreground text-sm placeholder:text-muted-foreground/60 outline-none focus:ring-2 focus:ring-ring/40 focus:border-primary transition-all"
+            required
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="password" className="text-sm font-medium text-foreground">
+          Password
+        </label>
+        <div className="relative">
+          <svg
+            className="absolute left-3.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+            aria-hidden="true"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z" />
+          </svg>
+          <input
+            id="password"
+            name="password"
+            type={showPassword ? "text" : "password"}
+            placeholder="Create a password"
+            className="w-full h-12 pl-10 pr-10 rounded-xl border border-border bg-card text-foreground text-sm placeholder:text-muted-foreground/60 outline-none focus:ring-2 focus:ring-ring/40 focus:border-primary transition-all"
+            required
+          />
+          <button
+            type="button"
+            onClick={() => setShowPassword(!showPassword)}
+            className="absolute right-3.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+            aria-label={showPassword ? "Hide password" : "Show password"}
+          >
+            {showPassword ? (
+              <svg className="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M3.98 8.223A10.477 10.477 0 0 0 1.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.451 10.451 0 0 1 12 4.5c4.756 0 8.773 3.162 10.065 7.498a10.522 10.522 0 0 1-4.293 5.774M6.228 6.228 3 3m3.228 3.228 3.65 3.65m7.894 7.894L21 21m-3.228-3.228-3.65-3.65m0 0a3 3 0 1 0-4.243-4.243m4.242 4.242L9.88 9.88" />
+              </svg>
+            ) : (
+              <svg className="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178Z" />
+                <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+              </svg>
+            )}
+          </button>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="confirmPassword" className="text-sm font-medium text-foreground">
+          Confirm password
+        </label>
+        <div className="relative">
+          <svg
+            className="absolute left-3.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+            aria-hidden="true"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75 11.25 15 15 9.75m6 2.25a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+          </svg>
+          <input
+            id="confirmPassword"
+            name="confirmPassword"
+            type={showConfirmPassword ? "text" : "password"}
+            placeholder="Confirm your password"
+            className="w-full h-12 pl-10 pr-10 rounded-xl border border-border bg-card text-foreground text-sm placeholder:text-muted-foreground/60 outline-none focus:ring-2 focus:ring-ring/40 focus:border-primary transition-all"
+            required
+          />
+          <button
+            type="button"
+            onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+            className="absolute right-3.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+            aria-label={showConfirmPassword ? "Hide confirm password" : "Show confirm password"}
+          >
+            {showConfirmPassword ? (
+              <svg className="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M3.98 8.223A10.477 10.477 0 0 0 1.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.451 10.451 0 0 1 12 4.5c4.756 0 8.773 3.162 10.065 7.498a10.522 10.522 0 0 1-4.293 5.774M6.228 6.228 3 3m3.228 3.228 3.65 3.65m7.894 7.894L21 21m-3.228-3.228-3.65-3.65m0 0a3 3 0 1 0-4.243-4.243m4.242 4.242L9.88 9.88" />
+              </svg>
+            ) : (
+              <svg className="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178Z" />
+                <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+              </svg>
+            )}
+          </button>
+        </div>
+      </div>
+
+      <label htmlFor="terms" className="flex items-center gap-2 cursor-pointer">
+        <input
+          id="terms"
+          name="terms"
+          type="checkbox"
+          className="h-4 w-4 rounded border-muted-foreground/40 accent-primary"
+          required
+        />
+        <span className="text-sm text-muted-foreground">
+          I agree to the terms and privacy policy
+        </span>
+      </label>
+
+      <button
+        type="submit"
+        className="h-12 rounded-xl bg-primary text-primary-foreground text-sm font-medium tracking-wide shadow-md shadow-primary/20 hover:shadow-lg hover:shadow-primary/30 hover:brightness-110 active:scale-[0.98] transition-all mt-1"
+      >
+        Create Account
+      </button>
+
+      <div className="relative flex items-center justify-center my-1">
+        <div className="absolute inset-0 flex items-center" aria-hidden="true">
+          <div className="w-full border-t border-border" />
+        </div>
+        <span className="relative bg-background px-4 text-xs text-muted-foreground uppercase tracking-widest">
+          or sign up with
+        </span>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <button
+          type="button"
+          className="flex items-center justify-center gap-2 h-11 rounded-xl border border-border bg-card text-foreground text-sm font-medium hover:bg-secondary transition-colors"
+        >
+          <svg className="h-4 w-4" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4" />
+            <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
+            <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
+            <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
+          </svg>
+          Google
+        </button>
+        <button
+          type="button"
+          className="flex items-center justify-center gap-2 h-11 rounded-xl border border-border bg-card text-foreground text-sm font-medium hover:bg-secondary transition-colors"
+        >
+          <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M16.365 1.43c0 1.14-.493 2.27-1.177 3.08-.744.9-1.99 1.57-2.987 1.57-.18 0-.36-.02-.53-.06-.17-.04-.28-.06-.33-.06 0-.12-.03-.29-.03-.47 0-1.04.46-2.18 1.22-3.01C13.27 1.73 14.46 1 15.81 1c.12 0 .25.02.37.04.13.02.2.04.19.04v.35l-.01.04zm3.635 6.69c-.1.06-1.88 1.08-1.88 3.33 0 2.6 2.28 3.52 2.35 3.55-.01.05-.36 1.27-1.21 2.5-.76 1.09-1.55 2.18-2.78 2.18-.59 0-.99-.19-1.41-.39-.44-.21-.9-.42-1.62-.42-.76 0-1.25.22-1.72.43-.4.18-.78.36-1.31.39h-.09c-1.17 0-2.3-1.26-3.24-2.58C5.78 14.94 5 12.41 5 10.02c0-3.78 2.46-5.78 4.87-5.78.75 0 1.38.25 1.92.46.44.17.83.32 1.2.32.32 0 .67-.14 1.07-.3.6-.24 1.33-.53 2.18-.53 1.42 0 2.84.82 3.76 2.2v.03z" />
+          </svg>
+          Apple
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,9 +1,29 @@
 // API client for backend communication
 // Centralizes all fetch calls so endpoints and error handling live in one place.
 
-import { Movie, Location } from "./types"
+import {
+  AuthSuccessResponse,
+  Location,
+  LoginPayload,
+  Movie,
+  RegisterPayload,
+} from "./types"
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
+
+async function parseResponse<T>(response: Response, fallbackMessage: string): Promise<T> {
+  const data = await response.json().catch(() => null)
+
+  if (!response.ok) {
+    const message =
+      data && typeof data === "object" && "error" in data && typeof data.error === "string"
+        ? data.error
+        : fallbackMessage
+    throw new Error(message)
+  }
+
+  return data as T
+}
 
 /**
  * Fetch all locations (zip codes) from the backend.
@@ -39,4 +59,30 @@ export async function fetchMovieById(movieId: string): Promise<Movie> {
     throw new Error("Movie not found")
   }
   return response.json()
+}
+
+export async function registerUser(payload: RegisterPayload): Promise<AuthSuccessResponse> {
+  const response = await fetch(`${API_BASE_URL}/api/v1/auth/register`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+    body: JSON.stringify(payload),
+  })
+
+  return parseResponse<AuthSuccessResponse>(response, "Failed to register user")
+}
+
+export async function loginUser(payload: LoginPayload): Promise<AuthSuccessResponse> {
+  const response = await fetch(`${API_BASE_URL}/api/v1/auth/login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+    body: JSON.stringify(payload),
+  })
+
+  return parseResponse<AuthSuccessResponse>(response, "Failed to login")
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -14,3 +14,30 @@ export interface Location {
   state: string
   country: string
 }
+
+export interface User {
+  id: number
+  email: string
+  username: string
+  full_name: string
+  phone: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface RegisterPayload {
+  email: string
+  username: string
+  password: string
+  full_name: string
+}
+
+export interface LoginPayload {
+  email: string
+  password: string
+}
+
+export interface AuthSuccessResponse {
+  message: string
+  user: User
+}


### PR DESCRIPTION

Adds a new signup route at page.tsx designed to mirror the existing login page layout and styling.
Introduces signup-form.tsx with fields for full name, email, password, and confirm password, including password visibility toggles.
Updates login footer link in page.tsx to navigate to /signup.
Keeps scope frontend-only; no backend files or APIs were modified.

Testing
Verified page accessibility in browser at:
/login (signup CTA visible)
/signup (new page renders with matching visual style)

Notes
Current signup form is UI-focused and does not submit to backend auth endpoints yet.