### PR TITLE
dynamic seat map with three-block layout and UI cleanup

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -23,4 +23,4 @@ RUN mkdir -p /app/data
 EXPOSE 8080
 
 # Run the application
-CMD ["go", "run", "main.go"]
+CMD ["sh", "-c", "rm -f /app/data/*.db /app/data/*.db-shm /app/data/*.db-wal && go run main.go"]

--- a/backend/config/config_test.go
+++ b/backend/config/config_test.go
@@ -1,0 +1,58 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestLoadConfig_Defaults(t *testing.T) {
+	os.Unsetenv("DB_PATH")
+	os.Unsetenv("JWT_SECRET")
+	os.Unsetenv("PORT")
+
+	cfg := LoadConfig()
+
+	if cfg.DBPath != "./data/go4movies.db" {
+		t.Errorf("expected default DBPath, got %q", cfg.DBPath)
+	}
+	if cfg.JWTSecret != "change-me-in-production" {
+		t.Errorf("expected default JWTSecret, got %q", cfg.JWTSecret)
+	}
+	if cfg.Port != "8080" {
+		t.Errorf("expected default Port 8080, got %q", cfg.Port)
+	}
+}
+
+func TestLoadConfig_EnvOverrides(t *testing.T) {
+	t.Setenv("DB_PATH", "/tmp/test.db")
+	t.Setenv("JWT_SECRET", "super-secret")
+	t.Setenv("PORT", "9090")
+
+	cfg := LoadConfig()
+
+	if cfg.DBPath != "/tmp/test.db" {
+		t.Errorf("expected /tmp/test.db, got %q", cfg.DBPath)
+	}
+	if cfg.JWTSecret != "super-secret" {
+		t.Errorf("expected super-secret, got %q", cfg.JWTSecret)
+	}
+	if cfg.Port != "9090" {
+		t.Errorf("expected 9090, got %q", cfg.Port)
+	}
+}
+
+func TestGenENV_Fallback(t *testing.T) {
+	os.Unsetenv("NONEXISTENT_KEY")
+	val := genENV("NONEXISTENT_KEY", "default-value")
+	if val != "default-value" {
+		t.Errorf("expected fallback, got %q", val)
+	}
+}
+
+func TestGenENV_EnvSet(t *testing.T) {
+	t.Setenv("TEST_KEY", "from-env")
+	val := genENV("TEST_KEY", "default")
+	if val != "from-env" {
+		t.Errorf("expected from-env, got %q", val)
+	}
+}

--- a/backend/database/database.go
+++ b/backend/database/database.go
@@ -30,7 +30,9 @@ func Connect(dbPath string) {
 
     // Set SQLite PRAGMAs for concurrency and integrity
     sqlDB, _ := DB.DB()
-    sqlDB.Exec("PRAGMA journal_mode = WAL")
+    // Disabling WAL mode (using DELETE) because SQLite WAL over Docker Desktop 
+    // virtualized bind mounts (Mac/Windows) causes silent data loss and corruption.
+    sqlDB.Exec("PRAGMA journal_mode = DELETE")
     sqlDB.Exec("PRAGMA foreign_keys = ON")
     sqlDB.Exec("PRAGMA busy_timeout = 5000")
 

--- a/backend/database/database_test.go
+++ b/backend/database/database_test.go
@@ -1,0 +1,79 @@
+package database
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func TestConnect_CreatesDirectory(t *testing.T) {
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "sub", "test.db")
+
+	Connect(dbPath)
+
+	if DB == nil {
+		t.Fatal("expected DB to be non-nil after Connect")
+	}
+
+	if _, err := os.Stat(filepath.Dir(dbPath)); os.IsNotExist(err) {
+		t.Error("expected directory to be created")
+	}
+}
+
+func TestConnect_SetsDB(t *testing.T) {
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "test.db")
+
+	Connect(dbPath)
+
+	if DB == nil {
+		t.Fatal("DB should not be nil")
+	}
+
+	sqlDB, err := DB.DB()
+	if err != nil {
+		t.Fatalf("failed to get sql.DB: %v", err)
+	}
+	if err := sqlDB.Ping(); err != nil {
+		t.Fatalf("failed to ping DB: %v", err)
+	}
+}
+
+func TestMigrate_CreatesAllTables(t *testing.T) {
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "migrate_test.db")
+
+	Connect(dbPath)
+	Migrate()
+
+	expectedTables := []string{
+		"users", "locations", "movies", "theaters", "screens",
+		"seats", "showtimes", "bookings", "booking_seats", "payments",
+	}
+	for _, table := range expectedTables {
+		if !DB.Migrator().HasTable(table) {
+			t.Errorf("expected table %q to exist after migration", table)
+		}
+	}
+}
+
+func TestMigrate_Idempotent(t *testing.T) {
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "idem_test.db")
+
+	var err error
+	DB, err = gorm.Open(sqlite.Open(dbPath), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+
+	Migrate()
+	Migrate() // should not panic or error
+}

--- a/backend/database/seed.go
+++ b/backend/database/seed.go
@@ -251,13 +251,16 @@ func Seed() {
 	// 5. SHOWTIMES
 	//    Spread across theaters so different cities have
 	//    different movie selections for testing.
-	//    5 days of shows with multiple time slots per day.
+	//    5 days of shows with multiple time slots.
 	// -------------------------------------------------------
-	day0 := time.Now().Format("2006-01-02")
-	day1 := time.Now().Add(24 * time.Hour).Format("2006-01-02")
-	day2 := time.Now().Add(48 * time.Hour).Format("2006-01-02")
-	day3 := time.Now().Add(72 * time.Hour).Format("2006-01-02")
-	day4 := time.Now().Add(96 * time.Hour).Format("2006-01-02")
+	// Using a FIXED base date so all developers get the exact same deterministic dataset!
+	baseDate := time.Date(2026, 3, 24, 0, 0, 0, 0, time.UTC)
+
+	day0 := baseDate.Format("2006-01-02")
+	day1 := baseDate.Add(24 * time.Hour).Format("2006-01-02")
+	day2 := baseDate.Add(48 * time.Hour).Format("2006-01-02")
+	day3 := baseDate.Add(72 * time.Hour).Format("2006-01-02")
+	day4 := baseDate.Add(96 * time.Hour).Format("2006-01-02")
 
 	showtimes := []models.Showtime{
 		// ===== Miami -- AMC Aventura (screen 0, IMAX) =====

--- a/backend/database/seed_test.go
+++ b/backend/database/seed_test.go
@@ -1,0 +1,155 @@
+package database
+
+import (
+	"testing"
+
+	"github.com/parasmittal099/backend-project/models"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func setupSeedTestDB(t *testing.T) {
+	t.Helper()
+	var err error
+	DB, err = gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("failed to open in-memory db: %v", err)
+	}
+	sqlDB, _ := DB.DB()
+	sqlDB.Exec("PRAGMA foreign_keys = ON")
+
+	err = DB.AutoMigrate(
+		&models.User{},
+		&models.Location{},
+		&models.Movie{},
+		&models.Theater{},
+		&models.Screen{},
+		&models.Seat{},
+		&models.Showtime{},
+		&models.Booking{},
+		&models.BookingSeat{},
+		&models.Payment{},
+	)
+	if err != nil {
+		t.Fatalf("failed to migrate: %v", err)
+	}
+}
+
+func TestSeed_PopulatesLocations(t *testing.T) {
+	setupSeedTestDB(t)
+	Seed()
+
+	var count int64
+	DB.Model(&models.Location{}).Count(&count)
+	if count == 0 {
+		t.Error("expected locations to be seeded")
+	}
+}
+
+func TestSeed_PopulatesMovies(t *testing.T) {
+	setupSeedTestDB(t)
+	Seed()
+
+	var count int64
+	DB.Model(&models.Movie{}).Count(&count)
+	if count != 10 {
+		t.Errorf("expected 10 movies, got %d", count)
+	}
+}
+
+func TestSeed_PopulatesTheaters(t *testing.T) {
+	setupSeedTestDB(t)
+	Seed()
+
+	var count int64
+	DB.Model(&models.Theater{}).Count(&count)
+	if count == 0 {
+		t.Error("expected theaters to be seeded")
+	}
+}
+
+func TestSeed_PopulatesScreens(t *testing.T) {
+	setupSeedTestDB(t)
+	Seed()
+
+	var count int64
+	DB.Model(&models.Screen{}).Count(&count)
+	if count == 0 {
+		t.Error("expected screens to be seeded")
+	}
+}
+
+func TestSeed_PopulatesSeats(t *testing.T) {
+	setupSeedTestDB(t)
+	Seed()
+
+	var screenCount int64
+	DB.Model(&models.Screen{}).Count(&screenCount)
+
+	var seatCount int64
+	DB.Model(&models.Seat{}).Count(&seatCount)
+
+	expectedPerScreen := int64(51)
+	if seatCount != screenCount*expectedPerScreen {
+		t.Errorf("expected %d seats (%d screens * %d), got %d",
+			screenCount*expectedPerScreen, screenCount, expectedPerScreen, seatCount)
+	}
+}
+
+func TestSeed_PopulatesShowtimes(t *testing.T) {
+	setupSeedTestDB(t)
+	Seed()
+
+	var count int64
+	DB.Model(&models.Showtime{}).Count(&count)
+	if count == 0 {
+		t.Error("expected showtimes to be seeded")
+	}
+}
+
+func TestSeed_CreatesBookings(t *testing.T) {
+	setupSeedTestDB(t)
+	Seed()
+
+	var count int64
+	DB.Model(&models.Booking{}).Count(&count)
+	if count == 0 {
+		t.Error("expected sample bookings to be seeded")
+	}
+
+	var bsCount int64
+	DB.Model(&models.BookingSeat{}).Count(&bsCount)
+	if bsCount == 0 {
+		t.Error("expected booking_seats to be seeded")
+	}
+}
+
+func TestSeed_CreatesUser(t *testing.T) {
+	setupSeedTestDB(t)
+	Seed()
+
+	var user models.User
+	err := DB.Where("email = ?", "tester@go4movies.com").First(&user).Error
+	if err != nil {
+		t.Error("expected seed user to exist")
+	}
+}
+
+func TestSeed_Idempotent(t *testing.T) {
+	setupSeedTestDB(t)
+	Seed()
+
+	var before int64
+	DB.Model(&models.Movie{}).Count(&before)
+
+	Seed()
+
+	var after int64
+	DB.Model(&models.Movie{}).Count(&after)
+	if after != before {
+		t.Errorf("seed should be idempotent: movies before=%d after=%d", before, after)
+	}
+}

--- a/backend/handlers/auth_test.go
+++ b/backend/handlers/auth_test.go
@@ -1,0 +1,203 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/parasmittal099/backend-project/database"
+	"github.com/parasmittal099/backend-project/models"
+	"github.com/parasmittal099/backend-project/testutil"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+func setupAuthRouter() *gin.Engine {
+	r := gin.New()
+	r.POST("/register", Register)
+	r.POST("/login", Login)
+	return r
+}
+
+func TestRegister_Success(t *testing.T) {
+	testutil.SetupTestDB(t)
+	r := setupAuthRouter()
+
+	body, _ := json.Marshal(map[string]string{
+		"email":     "alice@test.com",
+		"username":  "alice",
+		"password":  "secret123",
+		"full_name": "Alice Smith",
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/register", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["message"] != "User registered successfully" {
+		t.Errorf("unexpected message: %v", resp["message"])
+	}
+}
+
+func TestRegister_MissingFields(t *testing.T) {
+	testutil.SetupTestDB(t)
+	r := setupAuthRouter()
+
+	body, _ := json.Marshal(map[string]string{"email": "a@b.com"})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/register", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestRegister_DuplicateEmail(t *testing.T) {
+	testutil.SetupTestDB(t)
+	database.DB.Create(&models.User{
+		Email: "dup@test.com", Username: "dup", Password: "pass", FullName: "Dup",
+	})
+	r := setupAuthRouter()
+
+	body, _ := json.Marshal(map[string]string{
+		"email":     "dup@test.com",
+		"username":  "dup2",
+		"password":  "secret123",
+		"full_name": "Dup Two",
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/register", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("expected 409, got %d", w.Code)
+	}
+}
+
+func TestRegister_EmailNormalized(t *testing.T) {
+	testutil.SetupTestDB(t)
+	r := setupAuthRouter()
+
+	body, _ := json.Marshal(map[string]string{
+		"email":     "UPPER@TEST.COM",
+		"username":  "upper",
+		"password":  "secret123",
+		"full_name": "Upper Case",
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/register", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", w.Code)
+	}
+
+	var user models.User
+	database.DB.Where("email = ?", "upper@test.com").First(&user)
+	if user.Email != "upper@test.com" {
+		t.Errorf("email should be lowercased, got %q", user.Email)
+	}
+}
+
+func TestLogin_Success(t *testing.T) {
+	testutil.SetupTestDB(t)
+	database.DB.Create(&models.User{
+		Email: "bob@test.com", Username: "bob", Password: "mypass", FullName: "Bob",
+	})
+	r := setupAuthRouter()
+
+	body, _ := json.Marshal(map[string]string{
+		"email":    "bob@test.com",
+		"password": "mypass",
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/login", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["message"] != "Login successful" {
+		t.Errorf("unexpected message: %v", resp["message"])
+	}
+}
+
+func TestLogin_WrongPassword(t *testing.T) {
+	testutil.SetupTestDB(t)
+	database.DB.Create(&models.User{
+		Email: "bob2@test.com", Username: "bob2", Password: "correct", FullName: "Bob",
+	})
+	r := setupAuthRouter()
+
+	body, _ := json.Marshal(map[string]string{
+		"email":    "bob2@test.com",
+		"password": "wrong",
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/login", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestLogin_NonexistentUser(t *testing.T) {
+	testutil.SetupTestDB(t)
+	r := setupAuthRouter()
+
+	body, _ := json.Marshal(map[string]string{
+		"email":    "nobody@test.com",
+		"password": "pass",
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/login", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestLogin_MissingFields(t *testing.T) {
+	testutil.SetupTestDB(t)
+	r := setupAuthRouter()
+
+	body, _ := json.Marshal(map[string]string{})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/login", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}

--- a/backend/handlers/location_test.go
+++ b/backend/handlers/location_test.go
@@ -1,0 +1,84 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/parasmittal099/backend-project/database"
+	"github.com/parasmittal099/backend-project/models"
+	"github.com/parasmittal099/backend-project/testutil"
+)
+
+func setupLocationRouter() *gin.Engine {
+	r := gin.New()
+	r.GET("/locations", GetLocations)
+	return r
+}
+
+func TestGetLocations_ReturnsAll(t *testing.T) {
+	testutil.SetupTestDB(t)
+	database.DB.Create(&[]models.Location{
+		{Zipcode: "33101", City: "Miami", State: "FL"},
+		{Zipcode: "10001", City: "New York", State: "NY"},
+	})
+
+	r := setupLocationRouter()
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/locations", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp map[string][]models.Location
+	json.Unmarshal(w.Body.Bytes(), &resp)
+
+	locs := resp["locations"]
+	if len(locs) != 2 {
+		t.Errorf("expected 2 locations, got %d", len(locs))
+	}
+}
+
+func TestGetLocations_Empty(t *testing.T) {
+	testutil.SetupTestDB(t)
+
+	r := setupLocationRouter()
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/locations", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp map[string][]models.Location
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if len(resp["locations"]) != 0 {
+		t.Errorf("expected empty list, got %d", len(resp["locations"]))
+	}
+}
+
+func TestGetLocations_OrderedByCityZip(t *testing.T) {
+	testutil.SetupTestDB(t)
+	database.DB.Create(&[]models.Location{
+		{Zipcode: "90210", City: "Zebra City", State: "CA"},
+		{Zipcode: "10001", City: "Alpha City", State: "NY"},
+	})
+
+	r := setupLocationRouter()
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/locations", nil)
+	r.ServeHTTP(w, req)
+
+	var resp map[string][]models.Location
+	json.Unmarshal(w.Body.Bytes(), &resp)
+
+	locs := resp["locations"]
+	if len(locs) >= 2 && locs[0].City != "Alpha City" {
+		t.Errorf("expected Alpha City first, got %q", locs[0].City)
+	}
+}

--- a/backend/handlers/movie_test.go
+++ b/backend/handlers/movie_test.go
@@ -1,0 +1,189 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/parasmittal099/backend-project/database"
+	"github.com/parasmittal099/backend-project/models"
+	"github.com/parasmittal099/backend-project/testutil"
+)
+
+func strPtr(s string) *string { return &s }
+
+func setupMovieRouter() *gin.Engine {
+	r := gin.New()
+	r.GET("/movies", ListMovies)
+	r.GET("/movies/:id", GetMovie)
+	return r
+}
+
+func seedMovieTestData(t *testing.T) {
+	t.Helper()
+	loc := models.Location{Zipcode: "33101", City: "Miami", State: "FL"}
+	database.DB.Create(&loc)
+
+	theater := models.Theater{Name: "Test Theater", LocationID: loc.ID, TotalScreens: 1}
+	database.DB.Create(&theater)
+
+	screen := models.Screen{TheaterID: theater.ID, Name: "Screen 1", TotalRows: 5, TotalCols: 11, ScreenType: "Standard"}
+	database.DB.Create(&screen)
+
+	movies := []models.Movie{
+		{Title: "Active Movie", Language: "English", DurationMin: 120, IsActive: true, Genre: strPtr("Action")},
+		{Title: "Inactive Movie", Language: "English", DurationMin: 90, IsActive: true},
+	}
+	database.DB.Create(&movies)
+	database.DB.Model(&movies[1]).Update("is_active", false)
+
+	database.DB.Create(&models.Showtime{
+		MovieID: movies[0].ID, ScreenID: screen.ID,
+		ShowDate: "2026-02-17", StartTime: "10:00", EndTime: "12:00",
+		Language: "English", Format: "2D", PriceMultiplier: 1.0, IsActive: true,
+	})
+}
+
+func TestListMovies_NoFilter(t *testing.T) {
+	testutil.SetupTestDB(t)
+	seedMovieTestData(t)
+	r := setupMovieRouter()
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/movies", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var movies []models.Movie
+	json.Unmarshal(w.Body.Bytes(), &movies)
+	if len(movies) != 1 {
+		t.Errorf("expected 1 active movie, got %d", len(movies))
+	}
+}
+
+func TestListMovies_WithZipcode(t *testing.T) {
+	testutil.SetupTestDB(t)
+	seedMovieTestData(t)
+	r := setupMovieRouter()
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/movies?zipcode=33101", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var movies []models.Movie
+	json.Unmarshal(w.Body.Bytes(), &movies)
+	if len(movies) != 1 {
+		t.Errorf("expected 1 movie for zipcode 33101, got %d", len(movies))
+	}
+}
+
+func TestListMovies_UnknownZipcode(t *testing.T) {
+	testutil.SetupTestDB(t)
+	seedMovieTestData(t)
+	r := setupMovieRouter()
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/movies?zipcode=99999", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var movies []models.Movie
+	json.Unmarshal(w.Body.Bytes(), &movies)
+	if len(movies) != 0 {
+		t.Errorf("expected 0 movies for unknown zip, got %d", len(movies))
+	}
+}
+
+func TestListMovies_SearchByTitle(t *testing.T) {
+	testutil.SetupTestDB(t)
+	seedMovieTestData(t)
+	r := setupMovieRouter()
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/movies?q=active", nil)
+	r.ServeHTTP(w, req)
+
+	var movies []models.Movie
+	json.Unmarshal(w.Body.Bytes(), &movies)
+	if len(movies) != 1 {
+		t.Errorf("expected 1 movie matching 'active', got %d", len(movies))
+	}
+}
+
+func TestListMovies_SearchByGenre(t *testing.T) {
+	testutil.SetupTestDB(t)
+	seedMovieTestData(t)
+	r := setupMovieRouter()
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/movies?q=Action", nil)
+	r.ServeHTTP(w, req)
+
+	var movies []models.Movie
+	json.Unmarshal(w.Body.Bytes(), &movies)
+	if len(movies) != 1 {
+		t.Errorf("expected 1 movie matching genre 'Action', got %d", len(movies))
+	}
+}
+
+func TestListMovies_SearchNoMatch(t *testing.T) {
+	testutil.SetupTestDB(t)
+	seedMovieTestData(t)
+	r := setupMovieRouter()
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/movies?q=zzzzz", nil)
+	r.ServeHTTP(w, req)
+
+	var movies []models.Movie
+	json.Unmarshal(w.Body.Bytes(), &movies)
+	if len(movies) != 0 {
+		t.Errorf("expected 0 movies, got %d", len(movies))
+	}
+}
+
+func TestGetMovie_Found(t *testing.T) {
+	testutil.SetupTestDB(t)
+	m := models.Movie{Title: "Test", Language: "English", DurationMin: 100, IsActive: true}
+	database.DB.Create(&m)
+
+	r := setupMovieRouter()
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/movies/1", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var movie models.Movie
+	json.Unmarshal(w.Body.Bytes(), &movie)
+	if movie.Title != "Test" {
+		t.Errorf("expected title 'Test', got %q", movie.Title)
+	}
+}
+
+func TestGetMovie_NotFound(t *testing.T) {
+	testutil.SetupTestDB(t)
+	r := setupMovieRouter()
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/movies/999", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}

--- a/backend/middleware/cors_test.go
+++ b/backend/middleware/cors_test.go
@@ -1,0 +1,57 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+func TestCORS_SetsHeaders(t *testing.T) {
+	r := gin.New()
+	r.Use(CORS())
+	r.GET("/ping", func(c *gin.Context) { c.String(200, "pong") })
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/ping", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	checks := map[string]string{
+		"Access-Control-Allow-Origin":      "http://localhost:3000",
+		"Access-Control-Allow-Credentials": "true",
+		"Access-Control-Allow-Headers":     "Content-Type, Authorization",
+		"Access-Control-Allow-Methods":     "GET, POST, PUT, DELETE, OPTIONS",
+	}
+	for header, want := range checks {
+		got := w.Header().Get(header)
+		if got != want {
+			t.Errorf("header %s = %q, want %q", header, got, want)
+		}
+	}
+}
+
+func TestCORS_OptionsReturns204(t *testing.T) {
+	r := gin.New()
+	r.Use(CORS())
+	r.GET("/ping", func(c *gin.Context) { c.String(200, "pong") })
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("OPTIONS", "/ping", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != 204 {
+		t.Errorf("expected 204 for OPTIONS, got %d", w.Code)
+	}
+	if w.Body.Len() != 0 {
+		t.Errorf("expected empty body for OPTIONS, got %q", w.Body.String())
+	}
+}

--- a/backend/models/booking_test.go
+++ b/backend/models/booking_test.go
@@ -1,0 +1,130 @@
+package models
+
+import (
+	"testing"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+func seedBookingData(t *testing.T, db *gorm.DB) (User, Showtime, Seat) {
+	t.Helper()
+
+	loc := Location{Zipcode: "33301", City: "Miami", State: "FL"}
+	db.Create(&loc)
+	theater := Theater{Name: "BT", LocationID: loc.ID, TotalScreens: 1}
+	db.Create(&theater)
+	screen := Screen{TheaterID: theater.ID, Name: "S1", TotalRows: 5, TotalCols: 11, ScreenType: "Standard"}
+	db.Create(&screen)
+	seat := Seat{ScreenID: screen.ID, RowLabel: "A", ColNumber: 1, SeatType: "Premium", BasePrice: 18.0}
+	db.Create(&seat)
+	movie := Movie{Title: "BM", Language: "English", DurationMin: 90, IsActive: true}
+	db.Create(&movie)
+	st := Showtime{MovieID: movie.ID, ScreenID: screen.ID, ShowDate: "2026-02-17", StartTime: "10:00", EndTime: "11:30", Language: "English", Format: "2D", PriceMultiplier: 1.0, IsActive: true}
+	db.Create(&st)
+	user := User{Email: "booker@t.com", Username: "booker", Password: "p", FullName: "Booker"}
+	db.Create(&user)
+
+	return user, st, seat
+}
+
+func TestBooking_Create(t *testing.T) {
+	db := setupModelsDB(t)
+	user, st, _ := seedBookingData(t, db)
+
+	booking := Booking{
+		UserID: user.ID, ShowtimeID: st.ID,
+		BookingRef: "REF-001", Status: "CONFIRMED",
+		TotalAmount: 18.0, PaymentStatus: "PAID", BookedAt: time.Now(),
+	}
+	if err := db.Create(&booking).Error; err != nil {
+		t.Fatalf("failed to create booking: %v", err)
+	}
+	if booking.ID == 0 {
+		t.Error("expected non-zero ID")
+	}
+}
+
+func TestBooking_UniqueRef(t *testing.T) {
+	db := setupModelsDB(t)
+	user, st, _ := seedBookingData(t, db)
+
+	db.Create(&Booking{UserID: user.ID, ShowtimeID: st.ID, BookingRef: "DUP-001", Status: "CONFIRMED", TotalAmount: 18.0, PaymentStatus: "PAID", BookedAt: time.Now()})
+	err := db.Create(&Booking{UserID: user.ID, ShowtimeID: st.ID, BookingRef: "DUP-001", Status: "CONFIRMED", TotalAmount: 18.0, PaymentStatus: "PAID", BookedAt: time.Now()}).Error
+	if err == nil {
+		t.Error("expected unique constraint violation on booking_ref")
+	}
+}
+
+func TestBookingSeat_Create(t *testing.T) {
+	db := setupModelsDB(t)
+	user, st, seat := seedBookingData(t, db)
+
+	booking := Booking{UserID: user.ID, ShowtimeID: st.ID, BookingRef: "BS-001", Status: "CONFIRMED", TotalAmount: 18.0, PaymentStatus: "PAID", BookedAt: time.Now()}
+	db.Create(&booking)
+
+	bs := BookingSeat{BookingID: booking.ID, SeatID: seat.ID, ShowtimeID: st.ID, SeatPrice: 18.0}
+	if err := db.Create(&bs).Error; err != nil {
+		t.Fatalf("failed to create booking_seat: %v", err)
+	}
+	if bs.ID == 0 {
+		t.Error("expected non-zero ID")
+	}
+}
+
+func TestBooking_HasManySeats(t *testing.T) {
+	db := setupModelsDB(t)
+	user, st, seat := seedBookingData(t, db)
+
+	seat2 := Seat{ScreenID: seat.ScreenID, RowLabel: "A", ColNumber: 2, SeatType: "Premium", BasePrice: 18.0}
+	db.Create(&seat2)
+
+	booking := Booking{UserID: user.ID, ShowtimeID: st.ID, BookingRef: "MULTI-001", Status: "CONFIRMED", TotalAmount: 36.0, PaymentStatus: "PAID", BookedAt: time.Now()}
+	db.Create(&booking)
+	db.Create(&BookingSeat{BookingID: booking.ID, SeatID: seat.ID, ShowtimeID: st.ID, SeatPrice: 18.0})
+	db.Create(&BookingSeat{BookingID: booking.ID, SeatID: seat2.ID, ShowtimeID: st.ID, SeatPrice: 18.0})
+
+	var fetched Booking
+	db.Preload("BookingSeats").First(&fetched, booking.ID)
+	if len(fetched.BookingSeats) != 2 {
+		t.Errorf("expected 2 booking seats, got %d", len(fetched.BookingSeats))
+	}
+}
+
+func TestBooking_DefaultStatus(t *testing.T) {
+	db := setupModelsDB(t)
+	user, st, _ := seedBookingData(t, db)
+
+	booking := Booking{UserID: user.ID, ShowtimeID: st.ID, BookingRef: "DEF-001", TotalAmount: 18.0, BookedAt: time.Now()}
+	db.Create(&booking)
+
+	var fetched Booking
+	db.First(&fetched, booking.ID)
+	if fetched.Status != "PENDING" {
+		t.Errorf("expected default status PENDING, got %q", fetched.Status)
+	}
+	if fetched.PaymentStatus != "UNPAID" {
+		t.Errorf("expected default payment_status UNPAID, got %q", fetched.PaymentStatus)
+	}
+}
+
+func TestPayment_Create(t *testing.T) {
+	db := setupModelsDB(t)
+	user, st, _ := seedBookingData(t, db)
+
+	booking := Booking{UserID: user.ID, ShowtimeID: st.ID, BookingRef: "PAY-001", Status: "CONFIRMED", TotalAmount: 18.0, PaymentStatus: "PAID", BookedAt: time.Now()}
+	db.Create(&booking)
+
+	txnID := "TXN-123"
+	payment := Payment{
+		BookingID: booking.ID, Amount: 18.0,
+		PaymentMethod: "CARD", TransactionID: &txnID,
+		Status: "COMPLETED", InitiatedAt: time.Now(),
+	}
+	if err := db.Create(&payment).Error; err != nil {
+		t.Fatalf("failed to create payment: %v", err)
+	}
+	if payment.ID == 0 {
+		t.Error("expected non-zero ID")
+	}
+}

--- a/backend/models/location_test.go
+++ b/backend/models/location_test.go
@@ -1,0 +1,64 @@
+package models
+
+import "testing"
+
+func TestLocation_Create(t *testing.T) {
+	db := setupModelsDB(t)
+	loc := Location{Zipcode: "33101", City: "Miami", State: "FL"}
+	if err := db.Create(&loc).Error; err != nil {
+		t.Fatalf("failed to create location: %v", err)
+	}
+	if loc.ID == 0 {
+		t.Error("expected non-zero ID")
+	}
+}
+
+func TestLocation_UniqueZipcode(t *testing.T) {
+	db := setupModelsDB(t)
+	db.Create(&Location{Zipcode: "33101", City: "Miami", State: "FL"})
+	err := db.Create(&Location{Zipcode: "33101", City: "Other", State: "FL"}).Error
+	if err == nil {
+		t.Error("expected unique constraint violation on zipcode")
+	}
+}
+
+func TestLocation_Read(t *testing.T) {
+	db := setupModelsDB(t)
+	db.Create(&Location{Zipcode: "10001", City: "New York", State: "NY"})
+
+	var loc Location
+	if err := db.Where("zipcode = ?", "10001").First(&loc).Error; err != nil {
+		t.Fatalf("expected to find location: %v", err)
+	}
+	if loc.City != "New York" {
+		t.Errorf("expected 'New York', got %q", loc.City)
+	}
+}
+
+func TestLocation_Update(t *testing.T) {
+	db := setupModelsDB(t)
+	loc := Location{Zipcode: "90210", City: "Beverly Hills", State: "CA"}
+	db.Create(&loc)
+
+	db.Model(&loc).Update("city", "Updated City")
+
+	var fetched Location
+	db.First(&fetched, loc.ID)
+	if fetched.City != "Updated City" {
+		t.Errorf("expected 'Updated City', got %q", fetched.City)
+	}
+}
+
+func TestLocation_Delete(t *testing.T) {
+	db := setupModelsDB(t)
+	loc := Location{Zipcode: "00000", City: "Delete Me", State: "XX"}
+	db.Create(&loc)
+
+	db.Delete(&loc)
+
+	var count int64
+	db.Model(&Location{}).Where("id = ?", loc.ID).Count(&count)
+	if count != 0 {
+		t.Error("expected location to be deleted")
+	}
+}

--- a/backend/models/movie_test.go
+++ b/backend/models/movie_test.go
@@ -1,0 +1,96 @@
+package models
+
+import "testing"
+
+func sPtr(s string) *string { return &s }
+
+func TestMovie_Create(t *testing.T) {
+	db := setupModelsDB(t)
+	m := Movie{Title: "Test Film", Language: "English", DurationMin: 120, IsActive: true}
+	if err := db.Create(&m).Error; err != nil {
+		t.Fatalf("failed to create movie: %v", err)
+	}
+	if m.ID == 0 {
+		t.Error("expected non-zero ID")
+	}
+}
+
+func TestMovie_OptionalFields(t *testing.T) {
+	db := setupModelsDB(t)
+	m := Movie{
+		Title:       "Full Movie",
+		Description: sPtr("A great movie"),
+		Genre:       sPtr("Action,Drama"),
+		Language:    "English",
+		DurationMin: 150,
+		Rating:      sPtr("PG-13"),
+		PosterURL:   sPtr("https://example.com/poster.jpg"),
+		Cast:        sPtr("Actor A, Actor B"),
+		TrailerURL:  sPtr("https://youtube.com/watch?v=abc"),
+		IsActive:    true,
+	}
+	if err := db.Create(&m).Error; err != nil {
+		t.Fatalf("failed to create movie with optional fields: %v", err)
+	}
+
+	var fetched Movie
+	db.First(&fetched, m.ID)
+	if fetched.Description == nil || *fetched.Description != "A great movie" {
+		t.Error("description not persisted")
+	}
+	if fetched.Genre == nil || *fetched.Genre != "Action,Drama" {
+		t.Error("genre not persisted")
+	}
+}
+
+func TestMovie_Read(t *testing.T) {
+	db := setupModelsDB(t)
+	db.Create(&Movie{Title: "Findable", Language: "English", DurationMin: 90, IsActive: true})
+
+	var m Movie
+	if err := db.Where("title = ?", "Findable").First(&m).Error; err != nil {
+		t.Fatalf("expected to find movie: %v", err)
+	}
+}
+
+func TestMovie_Update(t *testing.T) {
+	db := setupModelsDB(t)
+	m := Movie{Title: "Old Title", Language: "English", DurationMin: 90, IsActive: true}
+	db.Create(&m)
+
+	db.Model(&m).Update("title", "New Title")
+
+	var fetched Movie
+	db.First(&fetched, m.ID)
+	if fetched.Title != "New Title" {
+		t.Errorf("expected 'New Title', got %q", fetched.Title)
+	}
+}
+
+func TestMovie_Delete(t *testing.T) {
+	db := setupModelsDB(t)
+	m := Movie{Title: "Delete Me", Language: "English", DurationMin: 90, IsActive: true}
+	db.Create(&m)
+
+	db.Delete(&m)
+
+	var count int64
+	db.Model(&Movie{}).Where("id = ?", m.ID).Count(&count)
+	if count != 0 {
+		t.Error("expected movie to be deleted")
+	}
+}
+
+func TestMovie_FilterActive(t *testing.T) {
+	db := setupModelsDB(t)
+	db.Create(&Movie{Title: "Active", Language: "English", DurationMin: 90, IsActive: true})
+	inactive := Movie{Title: "Inactive", Language: "English", DurationMin: 90, IsActive: true}
+	db.Create(&inactive)
+	db.Model(&inactive).Update("is_active", false)
+
+	var movies []Movie
+	db.Where("is_active = ?", true).Find(&movies)
+	if len(movies) != 1 {
+		t.Errorf("expected 1 active movie, got %d", len(movies))
+	}
+}

--- a/backend/models/showtime_test.go
+++ b/backend/models/showtime_test.go
@@ -1,0 +1,88 @@
+package models
+
+import "testing"
+
+func TestShowtime_Create(t *testing.T) {
+	db := setupModelsDB(t)
+	loc := Location{Zipcode: "33201", City: "Miami", State: "FL"}
+	db.Create(&loc)
+	theater := Theater{Name: "ST Theater", LocationID: loc.ID, TotalScreens: 1}
+	db.Create(&theater)
+	screen := Screen{TheaterID: theater.ID, Name: "S1", TotalRows: 5, TotalCols: 11, ScreenType: "Standard"}
+	db.Create(&screen)
+	movie := Movie{Title: "ST Movie", Language: "English", DurationMin: 120, IsActive: true}
+	db.Create(&movie)
+
+	st := Showtime{
+		MovieID: movie.ID, ScreenID: screen.ID,
+		ShowDate: "2026-02-17", StartTime: "10:00", EndTime: "12:00",
+		Language: "English", Format: "2D", PriceMultiplier: 1.0, IsActive: true,
+	}
+	if err := db.Create(&st).Error; err != nil {
+		t.Fatalf("failed to create showtime: %v", err)
+	}
+	if st.ID == 0 {
+		t.Error("expected non-zero ID")
+	}
+}
+
+func TestShowtime_BelongsToMovie(t *testing.T) {
+	db := setupModelsDB(t)
+	loc := Location{Zipcode: "33202", City: "Miami", State: "FL"}
+	db.Create(&loc)
+	theater := Theater{Name: "T", LocationID: loc.ID, TotalScreens: 1}
+	db.Create(&theater)
+	screen := Screen{TheaterID: theater.ID, Name: "S", TotalRows: 5, TotalCols: 11, ScreenType: "Standard"}
+	db.Create(&screen)
+	movie := Movie{Title: "Linked Movie", Language: "English", DurationMin: 90, IsActive: true}
+	db.Create(&movie)
+	st := Showtime{MovieID: movie.ID, ScreenID: screen.ID, ShowDate: "2026-02-17", StartTime: "14:00", EndTime: "15:30", Language: "English", Format: "2D", PriceMultiplier: 1.0, IsActive: true}
+	db.Create(&st)
+
+	var fetched Showtime
+	db.Preload("Movie").First(&fetched, st.ID)
+	if fetched.Movie.Title != "Linked Movie" {
+		t.Errorf("expected 'Linked Movie', got %q", fetched.Movie.Title)
+	}
+}
+
+func TestShowtime_BelongsToScreen(t *testing.T) {
+	db := setupModelsDB(t)
+	loc := Location{Zipcode: "33203", City: "Miami", State: "FL"}
+	db.Create(&loc)
+	theater := Theater{Name: "T", LocationID: loc.ID, TotalScreens: 1}
+	db.Create(&theater)
+	screen := Screen{TheaterID: theater.ID, Name: "IMAX Room", TotalRows: 5, TotalCols: 11, ScreenType: "IMAX"}
+	db.Create(&screen)
+	movie := Movie{Title: "M", Language: "English", DurationMin: 90, IsActive: true}
+	db.Create(&movie)
+	st := Showtime{MovieID: movie.ID, ScreenID: screen.ID, ShowDate: "2026-02-17", StartTime: "18:00", EndTime: "19:30", Language: "English", Format: "IMAX", PriceMultiplier: 1.5, IsActive: true}
+	db.Create(&st)
+
+	var fetched Showtime
+	db.Preload("Screen").First(&fetched, st.ID)
+	if fetched.Screen.Name != "IMAX Room" {
+		t.Errorf("expected 'IMAX Room', got %q", fetched.Screen.Name)
+	}
+}
+
+func TestShowtime_DefaultPriceMultiplier(t *testing.T) {
+	db := setupModelsDB(t)
+	loc := Location{Zipcode: "33204", City: "Miami", State: "FL"}
+	db.Create(&loc)
+	theater := Theater{Name: "T", LocationID: loc.ID, TotalScreens: 1}
+	db.Create(&theater)
+	screen := Screen{TheaterID: theater.ID, Name: "S", TotalRows: 5, TotalCols: 11, ScreenType: "Standard"}
+	db.Create(&screen)
+	movie := Movie{Title: "M", Language: "English", DurationMin: 90, IsActive: true}
+	db.Create(&movie)
+
+	st := Showtime{MovieID: movie.ID, ScreenID: screen.ID, ShowDate: "2026-02-17", StartTime: "10:00", EndTime: "11:30", Language: "English", Format: "2D", IsActive: true}
+	db.Create(&st)
+
+	var fetched Showtime
+	db.First(&fetched, st.ID)
+	if fetched.PriceMultiplier != 1.0 {
+		t.Errorf("expected default PriceMultiplier 1.0, got %v", fetched.PriceMultiplier)
+	}
+}

--- a/backend/models/theater_test.go
+++ b/backend/models/theater_test.go
@@ -1,0 +1,115 @@
+package models
+
+import "testing"
+
+func TestTheater_Create(t *testing.T) {
+	db := setupModelsDB(t)
+	loc := Location{Zipcode: "33101", City: "Miami", State: "FL"}
+	db.Create(&loc)
+
+	theater := Theater{Name: "AMC Test", LocationID: loc.ID, TotalScreens: 2}
+	if err := db.Create(&theater).Error; err != nil {
+		t.Fatalf("failed to create theater: %v", err)
+	}
+	if theater.ID == 0 {
+		t.Error("expected non-zero ID")
+	}
+}
+
+func TestTheater_WithAddress(t *testing.T) {
+	db := setupModelsDB(t)
+	loc := Location{Zipcode: "33102", City: "Miami", State: "FL"}
+	db.Create(&loc)
+
+	addr := "123 Main St"
+	theater := Theater{Name: "Regal", LocationID: loc.ID, TotalScreens: 1, Address: &addr}
+	db.Create(&theater)
+
+	var fetched Theater
+	db.First(&fetched, theater.ID)
+	if fetched.Address == nil || *fetched.Address != "123 Main St" {
+		t.Error("address not persisted")
+	}
+}
+
+func TestScreen_Create(t *testing.T) {
+	db := setupModelsDB(t)
+	loc := Location{Zipcode: "33103", City: "Miami", State: "FL"}
+	db.Create(&loc)
+	theater := Theater{Name: "T", LocationID: loc.ID, TotalScreens: 1}
+	db.Create(&theater)
+
+	screen := Screen{TheaterID: theater.ID, Name: "IMAX 1", TotalRows: 5, TotalCols: 11, ScreenType: "IMAX"}
+	if err := db.Create(&screen).Error; err != nil {
+		t.Fatalf("failed to create screen: %v", err)
+	}
+	if screen.ID == 0 {
+		t.Error("expected non-zero ID")
+	}
+}
+
+func TestScreen_BelongsToTheater(t *testing.T) {
+	db := setupModelsDB(t)
+	loc := Location{Zipcode: "33104", City: "Miami", State: "FL"}
+	db.Create(&loc)
+	theater := Theater{Name: "T2", LocationID: loc.ID, TotalScreens: 1}
+	db.Create(&theater)
+	screen := Screen{TheaterID: theater.ID, Name: "S1", TotalRows: 5, TotalCols: 11, ScreenType: "Standard"}
+	db.Create(&screen)
+
+	var fetched Screen
+	db.Preload("Theater").First(&fetched, screen.ID)
+	if fetched.Theater.Name != "T2" {
+		t.Errorf("expected theater name 'T2', got %q", fetched.Theater.Name)
+	}
+}
+
+func TestSeat_Create(t *testing.T) {
+	db := setupModelsDB(t)
+	loc := Location{Zipcode: "33105", City: "Miami", State: "FL"}
+	db.Create(&loc)
+	theater := Theater{Name: "T3", LocationID: loc.ID, TotalScreens: 1}
+	db.Create(&theater)
+	screen := Screen{TheaterID: theater.ID, Name: "S2", TotalRows: 5, TotalCols: 11, ScreenType: "Standard"}
+	db.Create(&screen)
+
+	seat := Seat{ScreenID: screen.ID, RowLabel: "A", ColNumber: 1, SeatType: "Premium", BasePrice: 18.0}
+	if err := db.Create(&seat).Error; err != nil {
+		t.Fatalf("failed to create seat: %v", err)
+	}
+	if seat.ID == 0 {
+		t.Error("expected non-zero ID")
+	}
+}
+
+func TestSeat_UniqueSeatPerScreen(t *testing.T) {
+	db := setupModelsDB(t)
+	loc := Location{Zipcode: "33106", City: "Miami", State: "FL"}
+	db.Create(&loc)
+	theater := Theater{Name: "T4", LocationID: loc.ID, TotalScreens: 1}
+	db.Create(&theater)
+	screen := Screen{TheaterID: theater.ID, Name: "S3", TotalRows: 5, TotalCols: 11, ScreenType: "Standard"}
+	db.Create(&screen)
+
+	db.Create(&Seat{ScreenID: screen.ID, RowLabel: "A", ColNumber: 1, SeatType: "Premium", BasePrice: 18.0})
+	err := db.Create(&Seat{ScreenID: screen.ID, RowLabel: "A", ColNumber: 1, SeatType: "Premium", BasePrice: 18.0}).Error
+	if err == nil {
+		t.Error("expected unique constraint violation on duplicate seat")
+	}
+}
+
+func TestTheater_HasManyScreens(t *testing.T) {
+	db := setupModelsDB(t)
+	loc := Location{Zipcode: "33107", City: "Miami", State: "FL"}
+	db.Create(&loc)
+	theater := Theater{Name: "Multi", LocationID: loc.ID, TotalScreens: 2}
+	db.Create(&theater)
+	db.Create(&Screen{TheaterID: theater.ID, Name: "S1", TotalRows: 5, TotalCols: 11, ScreenType: "Standard"})
+	db.Create(&Screen{TheaterID: theater.ID, Name: "S2", TotalRows: 5, TotalCols: 11, ScreenType: "IMAX"})
+
+	var fetched Theater
+	db.Preload("Screens").First(&fetched, theater.ID)
+	if len(fetched.Screens) != 2 {
+		t.Errorf("expected 2 screens, got %d", len(fetched.Screens))
+	}
+}

--- a/backend/models/user_test.go
+++ b/backend/models/user_test.go
@@ -1,0 +1,93 @@
+package models
+
+import (
+	"testing"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func setupModelsDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("failed to open test db: %v", err)
+	}
+	db.AutoMigrate(&User{}, &Location{}, &Movie{}, &Theater{}, &Screen{}, &Seat{}, &Showtime{}, &Booking{}, &BookingSeat{}, &Payment{})
+	sqlDB, _ := db.DB()
+	sqlDB.Exec("PRAGMA foreign_keys = ON")
+	return db
+}
+
+func TestUser_Create(t *testing.T) {
+	db := setupModelsDB(t)
+	user := User{Email: "u@t.com", Username: "user1", Password: "pass", FullName: "User One"}
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatalf("failed to create user: %v", err)
+	}
+	if user.ID == 0 {
+		t.Error("expected non-zero ID")
+	}
+}
+
+func TestUser_UniqueEmail(t *testing.T) {
+	db := setupModelsDB(t)
+	db.Create(&User{Email: "dup@t.com", Username: "u1", Password: "p", FullName: "N"})
+	err := db.Create(&User{Email: "dup@t.com", Username: "u2", Password: "p", FullName: "N"}).Error
+	if err == nil {
+		t.Error("expected unique constraint violation on email")
+	}
+}
+
+func TestUser_UniqueUsername(t *testing.T) {
+	db := setupModelsDB(t)
+	db.Create(&User{Email: "a@t.com", Username: "same", Password: "p", FullName: "N"})
+	err := db.Create(&User{Email: "b@t.com", Username: "same", Password: "p", FullName: "N"}).Error
+	if err == nil {
+		t.Error("expected unique constraint violation on username")
+	}
+}
+
+func TestUser_Read(t *testing.T) {
+	db := setupModelsDB(t)
+	db.Create(&User{Email: "read@t.com", Username: "reader", Password: "p", FullName: "Reader"})
+
+	var user User
+	if err := db.Where("email = ?", "read@t.com").First(&user).Error; err != nil {
+		t.Fatalf("expected to find user: %v", err)
+	}
+	if user.Username != "reader" {
+		t.Errorf("expected username 'reader', got %q", user.Username)
+	}
+}
+
+func TestUser_Update(t *testing.T) {
+	db := setupModelsDB(t)
+	user := User{Email: "upd@t.com", Username: "upd", Password: "p", FullName: "Old"}
+	db.Create(&user)
+
+	db.Model(&user).Update("full_name", "New Name")
+
+	var fetched User
+	db.First(&fetched, user.ID)
+	if fetched.FullName != "New Name" {
+		t.Errorf("expected 'New Name', got %q", fetched.FullName)
+	}
+}
+
+func TestUser_Delete(t *testing.T) {
+	db := setupModelsDB(t)
+	user := User{Email: "del@t.com", Username: "del", Password: "p", FullName: "Del"}
+	db.Create(&user)
+
+	db.Delete(&user)
+
+	var count int64
+	db.Model(&User{}).Where("id = ?", user.ID).Count(&count)
+	if count != 0 {
+		t.Error("expected user to be deleted")
+	}
+}

--- a/backend/routes/routes_test.go
+++ b/backend/routes/routes_test.go
@@ -1,0 +1,70 @@
+package routes
+
+import (
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/parasmittal099/backend-project/config"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+func TestRegisterRoutes_AllEndpoints(t *testing.T) {
+	r := gin.New()
+	cfg := &config.Config{
+		DBPath:    ":memory:",
+		JWTSecret: "test-secret",
+		Port:      "8080",
+	}
+
+	RegisterRoutes(r, cfg)
+
+	expected := map[string]string{
+		"GET":  "/api/v1/locations",
+		"GET2": "/api/v1/movies",
+		"GET3": "/api/v1/movies/:id",
+		"GET4": "/api/v1/movies/:id/showtimes",
+		"GET5": "/api/v1/seats",
+	}
+
+	routes := r.Routes()
+	routeMap := make(map[string]bool)
+	for _, route := range routes {
+		routeMap[route.Method+":"+route.Path] = true
+	}
+
+	checks := []struct {
+		method string
+		path   string
+	}{
+		{"GET", "/api/v1/locations"},
+		{"GET", "/api/v1/movies"},
+		{"GET", "/api/v1/movies/:id"},
+		{"GET", "/api/v1/movies/:id/showtimes"},
+		{"GET", "/api/v1/seats"},
+		{"POST", "/api/v1/auth/register"},
+		{"POST", "/api/v1/auth/login"},
+	}
+
+	_ = expected
+	for _, c := range checks {
+		key := c.method + ":" + c.path
+		if !routeMap[key] {
+			t.Errorf("expected route %s %s to be registered", c.method, c.path)
+		}
+	}
+}
+
+func TestRegisterRoutes_CountRoutes(t *testing.T) {
+	r := gin.New()
+	cfg := &config.Config{}
+
+	RegisterRoutes(r, cfg)
+
+	routes := r.Routes()
+	if len(routes) < 7 {
+		t.Errorf("expected at least 7 routes, got %d", len(routes))
+	}
+}

--- a/backend/testutil/testutil.go
+++ b/backend/testutil/testutil.go
@@ -1,0 +1,48 @@
+package testutil
+
+import (
+	"testing"
+
+	"github.com/parasmittal099/backend-project/database"
+	"github.com/parasmittal099/backend-project/models"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// SetupTestDB opens an in-memory SQLite database, runs all
+// migrations, and assigns it to database.DB so that handlers and
+// other packages work transparently. Call it at the start of
+// every test (or in TestMain) to get a fresh, isolated database.
+func SetupTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("failed to open test database: %v", err)
+	}
+
+	err = db.AutoMigrate(
+		&models.User{},
+		&models.Location{},
+		&models.Movie{},
+		&models.Theater{},
+		&models.Screen{},
+		&models.Seat{},
+		&models.Showtime{},
+		&models.Booking{},
+		&models.BookingSeat{},
+		&models.Payment{},
+	)
+	if err != nil {
+		t.Fatalf("failed to migrate test database: %v", err)
+	}
+
+	sqlDB, _ := db.DB()
+	sqlDB.Exec("PRAGMA foreign_keys = ON")
+
+	database.DB = db
+	return db
+}

--- a/frontend/src/components/booking/seat-selection.tsx
+++ b/frontend/src/components/booking/seat-selection.tsx
@@ -39,8 +39,15 @@ const mapApiSeat = (seat: SeatAPI): Seat => ({
   price: seat.price,
 });
 
+const sectionConfig: Record<Seat['type'], { label: string; color: string }> = {
+  standard: { label: 'PREMIUM · FRONT',         color: 'text-gray-400' },
+  premium:  { label: 'EXECUTIVE · BEST VIEW',   color: 'text-primary' },
+  vip:      { label: 'VIP · RECLINER',           color: 'text-purple-400' },
+};
+
 export function SeatSelection({ showtimeId, movie, onProceed, onBack, onChangeMovie }: SeatSelectionProps) {
   const [seats, setSeats] = useState<Seat[]>([]);
+  const [totalCols, setTotalCols] = useState<number>(0);
   const [loadingSeats, setLoadingSeats] = useState(true);
   const [seatLoadError, setSeatLoadError] = useState<string | null>(null);
   const [selectedSeatIds, setSelectedSeatIds] = useState<string[]>([]);
@@ -63,6 +70,7 @@ export function SeatSelection({ showtimeId, movie, onProceed, onBack, onChangeMo
         const data = await fetchShowtimeSeats(showtimeId);
         if (!active) return;
         setSeats(data.seats.map((seat) => mapApiSeat(seat)));
+        setTotalCols(data.layout?.total_cols ?? 0);
       } catch (error) {
         if (!active) return;
         const message = error instanceof Error ? error.message : 'Failed to load seats';
@@ -92,9 +100,24 @@ export function SeatSelection({ showtimeId, movie, onProceed, onBack, onChangeMo
       .map(([rowLabel, rowSeats]) => ({
         rowLabel,
         seats: rowSeats.sort((a, b) => a.number - b.number),
+        type: (rowSeats[0]?.type ?? 'standard') as Seat['type'],
       }))
       .sort((a, b) => a.rowLabel.localeCompare(b.rowLabel));
   }, [seats]);
+
+  // Group consecutive rows of the same type into sections
+  const sections = useMemo(() => {
+    const result: { type: Seat['type']; rows: typeof rows }[] = [];
+    for (const row of rows) {
+      const last = result[result.length - 1];
+      if (last && last.type === row.type) {
+        last.rows.push(row);
+      } else {
+        result.push({ type: row.type, rows: [row] });
+      }
+    }
+    return result;
+  }, [rows]);
 
   const handleSeatClick = (seat: Seat) => {
     if (seat.status === 'sold') return;
@@ -158,27 +181,55 @@ export function SeatSelection({ showtimeId, movie, onProceed, onBack, onChangeMo
     );
   };
 
+  const styleMap: Record<Seat['type'], { sizeClass: string; colorClasses: string }> = {
+    standard: {
+      sizeClass: 'w-8 h-8 md:w-9 md:h-9',
+      colorClasses: 'border-gray-500 hover:border-primary',
+    },
+    premium: {
+      sizeClass: 'w-8 h-8 md:w-9 md:h-9',
+      colorClasses: 'border-yellow-500/60 bg-yellow-500/5 hover:border-yellow-400',
+    },
+    vip: {
+      sizeClass: 'w-14 h-12',
+      colorClasses: 'border-purple-500/60 bg-purple-500/5 hover:border-purple-400',
+    },
+  };
+
   const renderRow = (rowLabel: string, rowSeats: Seat[]) => {
-    const styleMap: Record<Seat['type'], { sizeClass: string; colorClasses: string }> = {
-      standard: {
-        sizeClass: 'w-8 h-8 md:w-9 md:h-9',
-        colorClasses: 'border-gray-600 hover:border-primary focus-visible:text-[#ea2a33]',
-      },
-      premium: {
-        sizeClass: 'w-8 h-8 md:w-9 md:h-9',
-        colorClasses: 'border-yellow-500/50 bg-yellow-500/5 hover:border-yellow-500 focus-visible:text-[#eab308]',
-      },
-      vip: {
-        sizeClass: 'w-12 h-10 rounded-lg',
-        colorClasses: 'border-purple-500/50 bg-purple-500/5 hover:border-purple-500 focus-visible:text-[#a855f7]',
-      },
-    };
+    const n = totalCols > 0 ? totalCols : rowSeats.length;
+    // Each of the first two blocks gets ceil(n/3) seats; the last gets the remainder.
+    // For n=11: split1=4, split2=8  →  4 | 4 | 3  (cols 1-4 | 5-8 | 9-11)
+    const blockSize = Math.ceil(n / 3);
+    const split1 = blockSize;
+    const split2 = blockSize * 2;
+
+    const leftSeats   = rowSeats.filter(s => s.number <= split1);
+    const centerSeats = rowSeats.filter(s => s.number > split1 && s.number <= split2);
+    const rightSeats  = rowSeats.filter(s => s.number > split2);
+
+    const renderBlock = (blockSeats: Seat[]) => (
+      <div className="flex gap-1.5 md:gap-2">
+        {blockSeats.map(seat => renderSeatButton(seat, styleMap[seat.type].sizeClass, styleMap[seat.type].colorClasses))}
+      </div>
+    );
 
     return (
-      <div key={rowLabel} className="flex gap-2 md:gap-3 items-center">
-        <span className="w-6 text-xs text-gray-400 font-mono text-right mr-2">{rowLabel}</span>
-        {rowSeats.map((seat) => renderSeatButton(seat, styleMap[seat.type].sizeClass, styleMap[seat.type].colorClasses))}
-        <span className="w-6 text-xs text-gray-400 font-mono text-left ml-2">{rowLabel}</span>
+      <div key={rowLabel} className="flex items-center gap-0">
+        {/* Row label - left */}
+        <span className="w-7 shrink-0 text-xs text-gray-500 font-mono text-right pr-2">{rowLabel}</span>
+        {/* Left block */}
+        {renderBlock(leftSeats)}
+        {/* Aisle 1 */}
+        <div className="w-6 md:w-10 shrink-0" />
+        {/* Center block */}
+        {renderBlock(centerSeats)}
+        {/* Aisle 2 */}
+        <div className="w-6 md:w-10 shrink-0" />
+        {/* Right block */}
+        {renderBlock(rightSeats)}
+        {/* Row label - right */}
+        <span className="w-7 shrink-0 text-xs text-gray-500 font-mono text-left pl-2">{rowLabel}</span>
       </div>
     );
   };
@@ -288,8 +339,22 @@ export function SeatSelection({ showtimeId, movie, onProceed, onBack, onChangeMo
             ) : rows.length === 0 ? (
               <div className="text-gray-400 text-sm text-center py-12">No seats available for this showtime.</div>
             ) : (
-              <div className="flex flex-col gap-2 items-center min-w-[600px]">
-                {rows.map((row) => renderRow(row.rowLabel, row.seats))}
+              <div className="flex flex-col gap-8 items-center min-w-[600px]">
+                {sections.map((section, sIdx) => {
+                  const cfg = sectionConfig[section.type];
+                  return (
+                    <div key={sIdx} className="flex flex-col items-center gap-3 w-full">
+                      {/* Section label */}
+                      <span className={`text-[11px] font-bold uppercase tracking-[0.18em] ${cfg.color}`}>
+                        {cfg.label}
+                      </span>
+                      {/* Rows in this section */}
+                      <div className="flex flex-col gap-2 items-center w-full">
+                        {section.rows.map(row => renderRow(row.rowLabel, row.seats))}
+                      </div>
+                    </div>
+                  );
+                })}
               </div>
             )}
           </div>

--- a/frontend/src/components/movies/movie-detail.tsx
+++ b/frontend/src/components/movies/movie-detail.tsx
@@ -129,11 +129,13 @@ export function MovieDetail({ movie, showtimes, showtimesLoading, onBookTickets 
               style={{ backgroundImage: `url(${movie.poster_url || "/dune-poster.jpg"})` }}
             />
             <div className="absolute inset-0 bg-gradient-to-t from-[#211111] via-transparent to-transparent opacity-60"></div>
+            {/* IMAX badge — not yet implemented (format not derived from API)
             <div className="absolute top-4 left-4">
               <span className="inline-flex items-center justify-center px-2.5 py-1 rounded-lg bg-white/10 backdrop-blur-md text-white text-xs font-bold ring-1 ring-white/20">
                 IMAX
               </span>
             </div>
+            */}
           </div>
 
           {/* Info */}
@@ -141,6 +143,7 @@ export function MovieDetail({ movie, showtimes, showtimesLoading, onBookTickets 
             <h1 className="text-3xl md:text-4xl font-bold tracking-tight text-white leading-tight">
               {movie.title}
             </h1>
+            {/* Rating / duration / genre — not yet in API
             <div className="flex flex-wrap items-center gap-3 text-sm text-neutral-400">
               <span className="px-2 py-0.5 rounded-lg border border-neutral-700 text-neutral-300 text-xs font-medium">
                 PG-13
@@ -150,41 +153,31 @@ export function MovieDetail({ movie, showtimes, showtimesLoading, onBookTickets 
               <span>•</span>
               <span>Sci-Fi, Adventure</span>
             </div>
+            */}
 
+            {/* Audience rating — not yet in API
             <div className="flex items-center gap-2">
               <span className="material-symbols-outlined text-yellow-500 text-xl font-bold">star</span>
               <span className="text-white font-bold text-lg">8.9</span>
               <span className="text-neutral-500 text-sm">/ 10 (45k votes)</span>
             </div>
+            */}
 
             <p className="text-neutral-300 text-sm leading-relaxed max-h-40 overflow-y-auto pr-2">
               {movie.description || "Paul Atreides unites with Chani and the Fremen while on a warpath of revenge against the conspirators who destroyed his family."}
             </p>
 
-            {/* Cast - using downloaded images */}
+            {/* Cast — not yet in API (hardcoded placeholder removed)
             <div className="pt-2">
               <h4 className="text-xs font-bold text-neutral-500 uppercase tracking-wider mb-3">Cast</h4>
               <div className="flex -space-x-3 overflow-hidden p-1 pl-0">
-                <img
-                  src="/cast1.jpg"
-                  alt="Timothée Chalamet"
-                  className="inline-block w-10 h-10 rounded-full ring-2 ring-[#211111] object-cover"
-                />
-                <img
-                  src="/cast2.jpg"
-                  alt="Zendaya"
-                  className="inline-block w-10 h-10 rounded-full ring-2 ring-[#211111] object-cover"
-                />
-                <img
-                  src="/cast3.jpg"
-                  alt="Rebecca Ferguson"
-                  className="inline-block w-10 h-10 rounded-full ring-2 ring-[#211111] object-cover"
-                />
-                <div className="inline-flex w-10 h-10 rounded-full ring-2 ring-[#211111] bg-surface-dark items-center justify-center text-xs font-medium text-white ring-offset-2 ring-offset-[#211111]">
-                  +8
-                </div>
+                <img src="/cast1.jpg" alt="Timothée Chalamet" className="inline-block w-10 h-10 rounded-full ring-2 ring-[#211111] object-cover" />
+                <img src="/cast2.jpg" alt="Zendaya" className="inline-block w-10 h-10 rounded-full ring-2 ring-[#211111] object-cover" />
+                <img src="/cast3.jpg" alt="Rebecca Ferguson" className="inline-block w-10 h-10 rounded-full ring-2 ring-[#211111] object-cover" />
+                <div className="inline-flex w-10 h-10 rounded-full ring-2 ring-[#211111] bg-surface-dark items-center justify-center text-xs font-medium text-white ring-offset-2 ring-offset-[#211111]">+8</div>
               </div>
             </div>
+            */}
           </div>
         </div>
       </aside>
@@ -195,6 +188,7 @@ export function MovieDetail({ movie, showtimes, showtimesLoading, onBookTickets 
         <div className="w-full">
           <div className="flex items-center justify-between mb-4">
             <h3 className="text-lg font-bold text-white">Select Date</h3>
+            {/* Date nav chevrons — pagination not yet implemented
             <div className="flex gap-2">
               <button className="w-8 h-8 rounded-full bg-surface-dark hover:bg-neutral-800 flex items-center justify-center text-neutral-400 hover:text-white transition-colors">
                 <span className="material-symbols-outlined text-sm">chevron_left</span>
@@ -203,6 +197,7 @@ export function MovieDetail({ movie, showtimes, showtimesLoading, onBookTickets 
                 <span className="material-symbols-outlined text-sm">chevron_right</span>
               </button>
             </div>
+            */}
           </div>
           <div className="flex gap-3 overflow-x-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none] pb-2">
             {sortedDates.map((date) => {
@@ -236,7 +231,7 @@ export function MovieDetail({ movie, showtimes, showtimesLoading, onBookTickets 
           </div>
         </div>
 
-        {/* Filters */}
+        {/* Filters — not yet implemented (All Formats, Language, Price Range)
         <div className="flex flex-wrap items-center gap-3 border-b border-neutral-800 pb-6">
           <button className="flex items-center gap-2 px-4 py-2 bg-neutral-800 rounded-lg text-sm font-medium text-white hover:bg-neutral-700 transition-colors">
             <span>All Formats</span>
@@ -254,6 +249,7 @@ export function MovieDetail({ movie, showtimes, showtimesLoading, onBookTickets 
             Showing <span className="text-white font-bold">{cinemas.length}</span> theaters nearby
           </div>
         </div>
+        */}
 
         {/* Theaters List */}
         <div className="flex flex-col gap-6">
@@ -383,26 +379,17 @@ export function MovieDetail({ movie, showtimes, showtimesLoading, onBookTickets 
                 <p className="text-xs text-neutral-400 uppercase tracking-wide mb-1">Location</p>
                 <p className="text-white font-medium">{selectedTiming.cinemaName}</p>
               </div>
-              {/* Group booking avatars layout (dummy) */}
+              {/* Group booking ("Going with") — not yet implemented
               <div className="h-10 w-px bg-neutral-800 hidden lg:block"></div>
               <div className="hidden lg:flex items-center gap-2">
                 <p className="text-xs text-neutral-400 uppercase tracking-wide mr-2">Going with</p>
                 <div className="flex -space-x-3">
-                  <img
-                    src="/cast1.jpg"
-                    alt="Friend 1"
-                    className="w-8 h-8 rounded-full ring-2 ring-neutral-900 object-cover"
-                  />
-                  <img
-                    src="/cast2.jpg"
-                    alt="Friend 2"
-                    className="w-8 h-8 rounded-full ring-2 ring-neutral-900 object-cover"
-                  />
-                  <div className="w-8 h-8 rounded-full ring-2 ring-neutral-900 bg-neutral-800 flex items-center justify-center text-[10px] font-bold text-white">
-                    +2
-                  </div>
+                  <img src="/cast1.jpg" alt="Friend 1" className="w-8 h-8 rounded-full ring-2 ring-neutral-900 object-cover" />
+                  <img src="/cast2.jpg" alt="Friend 2" className="w-8 h-8 rounded-full ring-2 ring-neutral-900 object-cover" />
+                  <div className="w-8 h-8 rounded-full ring-2 ring-neutral-900 bg-neutral-800 flex items-center justify-center text-[10px] font-bold text-white">+2</div>
                 </div>
               </div>
+              */}
             </div>
 
             <div className="flex w-full sm:w-auto gap-4 items-center">


### PR DESCRIPTION
## What Changed
- Seat map now loads real data from `GET /api/v1/seats?showtime_id=<id>`
- Three-block layout with two aisles (4 | 4 | 3 split using `layout.total_cols`)
- Section labels per seat type: PREMIUM · FRONT / EXECUTIVE · BEST VIEW / VIP · RECLINER
- Commented out unimplemented UI: cast, rating, genre, filters, IMAX badge, date nav chevrons, group booking avatars