### PR TITLE
feat: Payments, checkout preview/confirm APIs with mock discount and unit tests

### DIFF
--- a/backend/handlers/checkout.go
+++ b/backend/handlers/checkout.go
@@ -1,0 +1,259 @@
+package handlers
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"math"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/parasmittal099/backend-project/database"
+	"github.com/parasmittal099/backend-project/models"
+)
+
+// Checkout defaults (no env for now; adjust later as needed).
+const (
+	checkoutTaxRate        = 0.08  // 8% on subtotal + convenience fee
+	checkoutConvenienceFee = 2.00  // flat per order
+	discountCodeMock100    = "MOCK100"
+)
+
+type checkoutRequest struct {
+	UserID        uint     `json:"user_id" binding:"required"`
+	ShowtimeID    uint     `json:"showtime_id" binding:"required"`
+	SeatIDs       []uint   `json:"seat_ids" binding:"required,min=1"`
+	DiscountCode  string   `json:"discount_code"`
+}
+
+type checkoutLineItem struct {
+	SeatID    uint    `json:"seat_id"`
+	RowLabel  string  `json:"row_label"`
+	ColNumber int     `json:"col_number"`
+	SeatType  string  `json:"seat_type"`
+	UnitPrice float64 `json:"unit_price"`
+}
+
+type checkoutTotals struct {
+	Subtotal        float64 `json:"subtotal"`
+	ConvenienceFee  float64 `json:"convenience_fee"`
+	TaxAmount       float64 `json:"tax_amount"`
+	DiscountCode    string  `json:"discount_code,omitempty"`
+	DiscountAmount  float64 `json:"discount_amount"`
+	TotalDue        float64 `json:"total_due"`
+}
+
+type checkoutQuote struct {
+	ShowtimeID uint               `json:"showtime_id"`
+	UserID     uint               `json:"user_id"`
+	LineItems  []checkoutLineItem `json:"line_items"`
+	Totals     checkoutTotals     `json:"totals"`
+}
+
+func roundMoney(v float64) float64 {
+	return math.Round(v*100) / 100
+}
+
+func seatUnitPrice(seat models.Seat, mult float64) float64 {
+	return roundMoney(seat.BasePrice * mult)
+}
+
+// validateAndQuote loads data, checks seats belong to showtime and are free, returns quote or HTTP error via gin.
+func validateAndQuote(req checkoutRequest, c *gin.Context) (*checkoutQuote, bool) {
+	var user models.User
+	if err := database.DB.First(&user, req.UserID).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "User not found"})
+		return nil, false
+	}
+
+	var showtime models.Showtime
+	if err := database.DB.First(&showtime, req.ShowtimeID).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Showtime not found"})
+		return nil, false
+	}
+	if !showtime.IsActive {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Showtime is not active"})
+		return nil, false
+	}
+
+	seen := make(map[uint]struct{})
+	for _, id := range req.SeatIDs {
+		if _, dup := seen[id]; dup {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Duplicate seat_id in request"})
+			return nil, false
+		}
+		seen[id] = struct{}{}
+	}
+
+	var seats []models.Seat
+	if err := database.DB.Where("id IN ? AND screen_id = ?", req.SeatIDs, showtime.ScreenID).Find(&seats).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to load seats"})
+		return nil, false
+	}
+	if len(seats) != len(req.SeatIDs) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "One or more seat_ids are invalid for this showtime"})
+		return nil, false
+	}
+
+	var conflict int64
+	err := database.DB.Table("booking_seats").
+		Joins("JOIN bookings ON bookings.id = booking_seats.booking_id").
+		Where("booking_seats.showtime_id = ? AND booking_seats.seat_id IN ? AND bookings.status IN ?",
+			showtime.ID, req.SeatIDs, []string{"PENDING", "CONFIRMED"}).
+		Count(&conflict).Error
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to check seat availability"})
+		return nil, false
+	}
+	if conflict > 0 {
+		c.JSON(http.StatusConflict, gin.H{"error": "One or more seats are no longer available"})
+		return nil, false
+	}
+
+	seatByID := make(map[uint]models.Seat, len(seats))
+	for _, s := range seats {
+		seatByID[s.ID] = s
+	}
+	lineItems := make([]checkoutLineItem, 0, len(req.SeatIDs))
+	var subtotal float64
+	for _, id := range req.SeatIDs {
+		seat := seatByID[id]
+		price := seatUnitPrice(seat, showtime.PriceMultiplier)
+		subtotal += price
+		lineItems = append(lineItems, checkoutLineItem{
+			SeatID:    seat.ID,
+			RowLabel:  seat.RowLabel,
+			ColNumber: seat.ColNumber,
+			SeatType:  seat.SeatType,
+			UnitPrice: price,
+		})
+	}
+	subtotal = roundMoney(subtotal)
+
+	taxable := subtotal + checkoutConvenienceFee
+	tax := roundMoney(taxable * checkoutTaxRate)
+	preDiscount := roundMoney(subtotal + checkoutConvenienceFee + tax)
+
+	discountAmt := 0.0
+	code := req.DiscountCode
+	if code == discountCodeMock100 {
+		discountAmt = preDiscount
+	}
+
+	totalDue := roundMoney(preDiscount - discountAmt)
+	if totalDue < 0 {
+		totalDue = 0
+	}
+
+	quote := &checkoutQuote{
+		ShowtimeID: showtime.ID,
+		UserID:     user.ID,
+		LineItems:  lineItems,
+		Totals: checkoutTotals{
+			Subtotal:       subtotal,
+			ConvenienceFee: checkoutConvenienceFee,
+			TaxAmount:      tax,
+			DiscountCode:   code,
+			DiscountAmount: discountAmt,
+			TotalDue:       totalDue,
+		},
+	}
+	return quote, true
+}
+
+// POST /api/v1/checkout/preview
+func PreviewCheckout(c *gin.Context) {
+	var req checkoutRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	quote, ok := validateAndQuote(req, c)
+	if !ok {
+		return
+	}
+	c.JSON(http.StatusOK, quote)
+}
+
+func newBookingRef() string {
+	b := make([]byte, 8)
+	_, _ = rand.Read(b)
+	return "G4M-" + hex.EncodeToString(b)
+}
+
+// POST /api/v1/checkout/confirm
+func ConfirmCheckout(c *gin.Context) {
+	var req checkoutRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	quote, ok := validateAndQuote(req, c)
+	if !ok {
+		return
+	}
+
+	now := time.Now()
+	booking := models.Booking{
+		UserID:         quote.UserID,
+		ShowtimeID:     quote.ShowtimeID,
+		BookingRef:     newBookingRef(),
+		Status:         "PENDING",
+		TotalAmount:    quote.Totals.TotalDue,
+		ConvenienceFee: quote.Totals.ConvenienceFee,
+		TaxAmount:      quote.Totals.TaxAmount,
+		PaymentStatus:  "UNPAID",
+		BookedAt:       now,
+	}
+	if err := database.DB.Create(&booking).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create booking"})
+		return
+	}
+
+	for _, li := range quote.LineItems {
+		bs := models.BookingSeat{
+			BookingID:  booking.ID,
+			SeatID:     li.SeatID,
+			ShowtimeID: quote.ShowtimeID,
+			SeatPrice:  li.UnitPrice,
+		}
+		if err := database.DB.Create(&bs).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save seat assignment", "booking_id": booking.ID})
+			return
+		}
+	}
+
+	// Mock checkout: always record payment as completed (real gateway would gate this).
+	payment := models.Payment{
+		BookingID:     booking.ID,
+		Amount:        quote.Totals.TotalDue,
+		PaymentMethod: "MOCK",
+		Status:        "COMPLETED",
+		InitiatedAt:   now,
+		CompletedAt:   &now,
+	}
+	if err := database.DB.Create(&payment).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to record payment", "booking_id": booking.ID})
+		return
+	}
+
+	bookingUpdates := map[string]interface{}{
+		"status":          "CONFIRMED",
+		"payment_status":  "PAID",
+		"total_amount":    quote.Totals.TotalDue,
+		"convenience_fee": quote.Totals.ConvenienceFee,
+		"tax_amount":      quote.Totals.TaxAmount,
+	}
+	if err := database.DB.Model(&booking).Updates(bookingUpdates).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to finalize booking", "booking_id": booking.ID})
+		return
+	}
+
+	c.JSON(http.StatusCreated, gin.H{
+		"message":     "Booking confirmed",
+		"booking_id":  booking.ID,
+		"booking_ref": booking.BookingRef,
+		"quote":       quote,
+		"payment_id":  payment.ID,
+	})
+}

--- a/backend/handlers/checkout_test.go
+++ b/backend/handlers/checkout_test.go
@@ -1,0 +1,351 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/parasmittal099/backend-project/database"
+	"github.com/parasmittal099/backend-project/models"
+	"github.com/parasmittal099/backend-project/testutil"
+)
+
+func setupCheckoutRouter() *gin.Engine {
+	r := gin.New()
+	r.POST("/checkout/preview", PreviewCheckout)
+	r.POST("/checkout/confirm", ConfirmCheckout)
+	return r
+}
+
+type checkoutSeed struct {
+	User     models.User
+	Showtime models.Showtime
+	Seat1    models.Seat
+	Seat2    models.Seat
+}
+
+func seedCheckoutData(t *testing.T) checkoutSeed {
+	t.Helper()
+
+	user := models.User{
+		Email: "checkout@test.com", Username: "checkoutuser",
+		Password: "secret12", FullName: "Checkout User",
+	}
+	if err := database.DB.Create(&user).Error; err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	loc := models.Location{Zipcode: "33101", City: "Miami", State: "FL"}
+	database.DB.Create(&loc)
+
+	addr := "1 Test St"
+	theater := models.Theater{Name: "Test Plex", LocationID: loc.ID, Address: &addr, TotalScreens: 1}
+	database.DB.Create(&theater)
+
+	screen := models.Screen{TheaterID: theater.ID, Name: "S1", TotalRows: 5, TotalCols: 10, ScreenType: "Standard"}
+	database.DB.Create(&screen)
+
+	movie := models.Movie{Title: "Checkout Movie", Language: "English", DurationMin: 100, IsActive: true}
+	database.DB.Create(&movie)
+
+	today := time.Now().Format("2006-01-02")
+	st := models.Showtime{
+		MovieID: movie.ID, ScreenID: screen.ID,
+		ShowDate: today, StartTime: "10:00", EndTime: "12:00",
+		Language: "English", Format: "2D", PriceMultiplier: 1.0, IsActive: true,
+	}
+	database.DB.Create(&st)
+
+	seat1 := models.Seat{ScreenID: screen.ID, RowLabel: "A", ColNumber: 1, SeatType: "Regular", BasePrice: 100}
+	seat2 := models.Seat{ScreenID: screen.ID, RowLabel: "A", ColNumber: 2, SeatType: "Regular", BasePrice: 100}
+	database.DB.Create(&seat1)
+	database.DB.Create(&seat2)
+
+	return checkoutSeed{User: user, Showtime: st, Seat1: seat1, Seat2: seat2}
+}
+
+func postJSONCheckout(t *testing.T, r *gin.Engine, path string, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	b, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, path, bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestPreviewCheckout_Success_NoDiscount(t *testing.T) {
+	testutil.SetupTestDB(t)
+	td := seedCheckoutData(t)
+	r := setupCheckoutRouter()
+
+	w := postJSONCheckout(t, r, "/checkout/preview", map[string]any{
+		"user_id":     td.User.ID,
+		"showtime_id": td.Showtime.ID,
+		"seat_ids":    []uint{td.Seat1.ID},
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+
+	totals := resp["totals"].(map[string]any)
+	// subtotal 100, fee 2, tax on 102 = 8.16, total 110.16
+	if totals["subtotal"].(float64) != 100 {
+		t.Errorf("subtotal want 100 got %v", totals["subtotal"])
+	}
+	if totals["convenience_fee"].(float64) != 2 {
+		t.Errorf("fee want 2 got %v", totals["convenience_fee"])
+	}
+	if totals["tax_amount"].(float64) != 8.16 {
+		t.Errorf("tax want 8.16 got %v", totals["tax_amount"])
+	}
+	if totals["total_due"].(float64) != 110.16 {
+		t.Errorf("total_due want 110.16 got %v", totals["total_due"])
+	}
+	if totals["discount_amount"].(float64) != 0 {
+		t.Errorf("discount want 0 got %v", totals["discount_amount"])
+	}
+}
+
+func TestPreviewCheckout_Mock100_ZeroTotal(t *testing.T) {
+	testutil.SetupTestDB(t)
+	td := seedCheckoutData(t)
+	r := setupCheckoutRouter()
+
+	w := postJSONCheckout(t, r, "/checkout/preview", map[string]any{
+		"user_id":        td.User.ID,
+		"showtime_id":    td.Showtime.ID,
+		"seat_ids":       []uint{td.Seat1.ID},
+		"discount_code":  discountCodeMock100,
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	totals := resp["totals"].(map[string]any)
+	if totals["total_due"].(float64) != 0 {
+		t.Errorf("total_due want 0 got %v", totals["total_due"])
+	}
+	pre := 100.0 + 2.0 + 8.16
+	if totals["discount_amount"].(float64) != pre {
+		t.Errorf("discount_amount want %v got %v", pre, totals["discount_amount"])
+	}
+}
+
+func TestPreviewCheckout_TwoSeats(t *testing.T) {
+	testutil.SetupTestDB(t)
+	td := seedCheckoutData(t)
+	r := setupCheckoutRouter()
+
+	w := postJSONCheckout(t, r, "/checkout/preview", map[string]any{
+		"user_id":     td.User.ID,
+		"showtime_id": td.Showtime.ID,
+		"seat_ids":    []uint{td.Seat1.ID, td.Seat2.ID},
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	items := resp["line_items"].([]any)
+	if len(items) != 2 {
+		t.Errorf("want 2 line items, got %d", len(items))
+	}
+}
+
+func TestPreviewCheckout_UserNotFound(t *testing.T) {
+	testutil.SetupTestDB(t)
+	td := seedCheckoutData(t)
+	r := setupCheckoutRouter()
+
+	w := postJSONCheckout(t, r, "/checkout/preview", map[string]any{
+		"user_id":     99999,
+		"showtime_id": td.Showtime.ID,
+		"seat_ids":    []uint{td.Seat1.ID},
+	})
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestPreviewCheckout_ShowtimeNotFound(t *testing.T) {
+	testutil.SetupTestDB(t)
+	td := seedCheckoutData(t)
+	r := setupCheckoutRouter()
+
+	w := postJSONCheckout(t, r, "/checkout/preview", map[string]any{
+		"user_id":     td.User.ID,
+		"showtime_id": 99999,
+		"seat_ids":    []uint{td.Seat1.ID},
+	})
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestPreviewCheckout_InactiveShowtime(t *testing.T) {
+	testutil.SetupTestDB(t)
+	td := seedCheckoutData(t)
+	database.DB.Model(&td.Showtime).Update("is_active", false)
+	r := setupCheckoutRouter()
+
+	w := postJSONCheckout(t, r, "/checkout/preview", map[string]any{
+		"user_id":     td.User.ID,
+		"showtime_id": td.Showtime.ID,
+		"seat_ids":    []uint{td.Seat1.ID},
+	})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestPreviewCheckout_InvalidSeatWrongScreen(t *testing.T) {
+	testutil.SetupTestDB(t)
+	td := seedCheckoutData(t)
+
+	var screen models.Screen
+	database.DB.First(&screen, td.Showtime.ScreenID)
+	theaterID := screen.TheaterID
+	os := models.Screen{TheaterID: theaterID, Name: "Screen 2", TotalRows: 2, TotalCols: 2, ScreenType: "Standard"}
+	database.DB.Create(&os)
+	badSeat := models.Seat{ScreenID: os.ID, RowLabel: "Z", ColNumber: 9, SeatType: "Regular", BasePrice: 50}
+	database.DB.Create(&badSeat)
+
+	r := setupCheckoutRouter()
+	w := postJSONCheckout(t, r, "/checkout/preview", map[string]any{
+		"user_id":     td.User.ID,
+		"showtime_id": td.Showtime.ID,
+		"seat_ids":    []uint{badSeat.ID},
+	})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestPreviewCheckout_DuplicateSeatID(t *testing.T) {
+	testutil.SetupTestDB(t)
+	td := seedCheckoutData(t)
+	r := setupCheckoutRouter()
+
+	w := postJSONCheckout(t, r, "/checkout/preview", map[string]any{
+		"user_id":     td.User.ID,
+		"showtime_id": td.Showtime.ID,
+		"seat_ids":    []uint{td.Seat1.ID, td.Seat1.ID},
+	})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestPreviewCheckout_SeatAlreadyBooked(t *testing.T) {
+	testutil.SetupTestDB(t)
+	td := seedCheckoutData(t)
+
+	booking := models.Booking{
+		UserID: td.User.ID, ShowtimeID: td.Showtime.ID, BookingRef: "EXIST-1",
+		Status: "CONFIRMED", TotalAmount: 100, ConvenienceFee: 0, TaxAmount: 0,
+		PaymentStatus: "PAID", BookedAt: time.Now(),
+	}
+	database.DB.Create(&booking)
+	database.DB.Create(&models.BookingSeat{
+		BookingID: booking.ID, SeatID: td.Seat1.ID, ShowtimeID: td.Showtime.ID, SeatPrice: 100,
+	})
+
+	r := setupCheckoutRouter()
+	w := postJSONCheckout(t, r, "/checkout/preview", map[string]any{
+		"user_id":     td.User.ID,
+		"showtime_id": td.Showtime.ID,
+		"seat_ids":    []uint{td.Seat1.ID},
+	})
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestPreviewCheckout_EmptyBody(t *testing.T) {
+	testutil.SetupTestDB(t)
+	seedCheckoutData(t)
+	r := setupCheckoutRouter()
+
+	w := postJSONCheckout(t, r, "/checkout/preview", map[string]any{})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestConfirmCheckout_CreatesBookingAndPayment(t *testing.T) {
+	testutil.SetupTestDB(t)
+	td := seedCheckoutData(t)
+	r := setupCheckoutRouter()
+
+	w := postJSONCheckout(t, r, "/checkout/confirm", map[string]any{
+		"user_id":        td.User.ID,
+		"showtime_id":    td.Showtime.ID,
+		"seat_ids":       []uint{td.Seat1.ID},
+		"discount_code":  discountCodeMock100,
+	})
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["booking_ref"] == nil || resp["booking_ref"] == "" {
+		t.Error("missing booking_ref")
+	}
+
+	var count int64
+	database.DB.Model(&models.Booking{}).Count(&count)
+	if count != 1 {
+		t.Errorf("want 1 booking, got %d", count)
+	}
+	database.DB.Model(&models.BookingSeat{}).Count(&count)
+	if count != 1 {
+		t.Errorf("want 1 booking_seat, got %d", count)
+	}
+	database.DB.Model(&models.Payment{}).Count(&count)
+	if count != 1 {
+		t.Errorf("want 1 payment, got %d", count)
+	}
+
+	var b models.Booking
+	database.DB.First(&b)
+	if b.Status != "CONFIRMED" || b.PaymentStatus != "PAID" {
+		t.Errorf("booking status want CONFIRMED/PAID, got %s/%s", b.Status, b.PaymentStatus)
+	}
+}
+
+func TestConfirmCheckout_ThenPreviewConflict(t *testing.T) {
+	testutil.SetupTestDB(t)
+	td := seedCheckoutData(t)
+	r := setupCheckoutRouter()
+
+	body := map[string]any{
+		"user_id":     td.User.ID,
+		"showtime_id": td.Showtime.ID,
+		"seat_ids":    []uint{td.Seat2.ID},
+	}
+	w1 := postJSONCheckout(t, r, "/checkout/confirm", body)
+	if w1.Code != http.StatusCreated {
+		t.Fatalf("confirm: %d %s", w1.Code, w1.Body.String())
+	}
+
+	w2 := postJSONCheckout(t, r, "/checkout/preview", body)
+	if w2.Code != http.StatusConflict {
+		t.Fatalf("second preview want 409, got %d: %s", w2.Code, w2.Body.String())
+	}
+}

--- a/backend/routes/routes.go
+++ b/backend/routes/routes.go
@@ -19,6 +19,9 @@ func RegisterRoutes(r *gin.Engine, cfg *config.Config) {
 		v1.GET("/movies/:id/showtimes", handlers.GetMovieShowtimes)
 		v1.GET("/seats", handlers.GetShowtimeSeats)
 
+		v1.POST("/checkout/preview", handlers.PreviewCheckout)
+		v1.POST("/checkout/confirm", handlers.ConfirmCheckout)
+
 		auth := v1.Group("/auth")
 		{
 			auth.POST("/register", handlers.Register)

--- a/backend/routes/routes_test.go
+++ b/backend/routes/routes_test.go
@@ -46,6 +46,8 @@ func TestRegisterRoutes_AllEndpoints(t *testing.T) {
 		{"GET", "/api/v1/seats"},
 		{"POST", "/api/v1/auth/register"},
 		{"POST", "/api/v1/auth/login"},
+		{"POST", "/api/v1/checkout/preview"},
+		{"POST", "/api/v1/checkout/confirm"},
 	}
 
 	_ = expected
@@ -64,7 +66,7 @@ func TestRegisterRoutes_CountRoutes(t *testing.T) {
 	RegisterRoutes(r, cfg)
 
 	routes := r.Routes()
-	if len(routes) < 7 {
-		t.Errorf("expected at least 7 routes, got %d", len(routes))
+	if len(routes) < 9 {
+		t.Errorf("expected at least 9 routes, got %d", len(routes))
 	}
 }


### PR DESCRIPTION
Summary
Adds POST /api/v1/checkout/preview and POST /api/v1/checkout/confirm for seat checkout: pricing (subtotal, $2 convenience fee, 8% tax), optional MOCK100 discount (sets total due to $0), and confirm flow that creates booking, booking_seats, and mock payment, then marks the booking CONFIRMED / PAID so seats show as taken in GET /api/v1/seats.

Notes
Writes are not wrapped in a DB transaction; concurrency is out of scope for now.
Tests
handlers/checkout_test.go — preview/confirm and error paths; routes_test.go updated for new routes.