### PR TITLE
Integrate checkout page with backend APIs

### DIFF
--- a/frontend/src/app/payment/page.tsx
+++ b/frontend/src/app/payment/page.tsx
@@ -1,8 +1,10 @@
 "use client"
 
-import { useMemo, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
 import { useAuth } from "@/context/auth-context"
+import { previewCheckout, confirmCheckout, fetchShowtimeSeats, type CheckoutPayload } from "@/lib/api"
+import type { CheckoutQuote, SeatsResponse } from "@/lib/types"
 
 export default function PaymentPage() {
   const router = useRouter()
@@ -33,6 +35,73 @@ export default function PaymentPage() {
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [successMessage, setSuccessMessage] = useState<string | null>(null)
 
+  const [discountCode, setDiscountCode] = useState("")
+  const [appliedDiscount, setAppliedDiscount] = useState("")
+  const [preview, setPreview] = useState<CheckoutQuote | null>(null)
+  const [previewLoading, setPreviewLoading] = useState(false)
+  const [previewError, setPreviewError] = useState<string | null>(null)
+  const [showtimeInfo, setShowtimeInfo] = useState<SeatsResponse["showtime"] | null>(null)
+  const [seatSubtotal, setSeatSubtotal] = useState<number | null>(null)
+  const [timerSeconds, setTimerSeconds] = useState(10 * 60)
+
+  const showtimeIdNum = Number(showtimeId)
+
+  useEffect(() => {
+    const intervalId = window.setInterval(() => {
+      setTimerSeconds((prev) => {
+        if (prev <= 1) {
+          window.clearInterval(intervalId)
+          return 0
+        }
+        return prev - 1
+      })
+    }, 1000)
+
+    return () => window.clearInterval(intervalId)
+  }, [])
+
+  // Fetch showtime info independently — does not require auth
+  useEffect(() => {
+    if (!showtimeIdNum) return
+    fetchShowtimeSeats(showtimeIdNum)
+      .then((seatsResp) => {
+        setShowtimeInfo(seatsResp.showtime)
+
+        const selectedSeatSet = new Set(selectedSeatDbIds)
+        const subtotal = seatsResp.seats
+          .filter((seat) => selectedSeatSet.has(seat.id))
+          .reduce((sum, seat) => sum + seat.price, 0)
+        setSeatSubtotal(Number(subtotal.toFixed(2)))
+      })
+      .catch(() => {/* showtime info is non-critical, silently skip */})
+  }, [showtimeIdNum, selectedSeatDbIds])
+
+  // Fetch pricing preview — requires user + seats
+  useEffect(() => {
+    if (!showtimeIdNum || selectedSeatDbIds.length === 0 || !user?.id) {
+      return
+    }
+    setPreviewLoading(true)
+    setPreviewError(null)
+
+    const payload: CheckoutPayload = {
+      user_id: user.id,
+      showtime_id: showtimeIdNum,
+      seat_ids: selectedSeatDbIds,
+      ...(appliedDiscount ? { discount_code: appliedDiscount } : {}),
+    }
+
+    previewCheckout(payload)
+      .then((quote) => setPreview(quote))
+      .catch((err) => {
+        setPreviewError(err instanceof Error ? err.message : "Failed to load checkout preview")
+      })
+      .finally(() => setPreviewLoading(false))
+  }, [showtimeIdNum, appliedDiscount, user?.id])
+
+  const handleApplyDiscount = () => {
+    setAppliedDiscount(discountCode.trim())
+  }
   const handlePay = async () => {
     setSubmitError(null)
     setSuccessMessage(null)
@@ -42,6 +111,10 @@ export default function PaymentPage() {
       setSubmitError("Missing showtime or seat details. Please reselect seats and try again.")
       return
     }
+    if (!user?.id) {
+      setSubmitError("You must be logged in to complete a booking.")
+      return
+    }
     if (!cardName.trim() || normalizedCard.length < 12 || !expiry.trim() || cvv.trim().length < 3) {
       setSubmitError("Please enter valid card details before proceeding.")
       return
@@ -49,39 +122,42 @@ export default function PaymentPage() {
 
     setSubmitting(true)
     try {
-      const payload = {
-        userId: user?.id ?? null,
-        showtimeId: Number(showtimeId),
-        seatIds: selectedSeatDbIds,
-        seatCodes: selectedSeats,
-        paymentMethod: "CARD",
-        cardHolderName: cardName.trim(),
-        cardLast4: normalizedCard.slice(-4),
-        saveCard,
-      }
-
-      const response = await fetch("/api/mock-booking", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(payload),
+      const data = await confirmCheckout({
+        user_id: user.id,
+        showtime_id: showtimeIdNum,
+        seat_ids: selectedSeatDbIds,
+        ...(appliedDiscount ? { discount_code: appliedDiscount } : {}),
       })
-
-      const data = await response.json().catch(() => null)
-      if (!response.ok) {
-        const message = data?.error ?? "Failed to submit booking payload"
-        throw new Error(message)
-      }
-
-      const ref = data?.reservation?.bookingRef ?? "N/A"
-      setSuccessMessage(`Payment payload submitted successfully. Mock booking ref: ${ref}`)
+      setSuccessMessage(`Booking confirmed! Your booking reference: ${data.booking_ref}`)
     } catch (error) {
       setSubmitError(error instanceof Error ? error.message : "Something went wrong while submitting")
     } finally {
       setSubmitting(false)
     }
   }
+
+  const totalDue = preview?.totals.total_due
+  const ticketSubtotal = preview?.totals.subtotal ?? seatSubtotal
+  const convenienceFee = preview?.totals.convenience_fee ?? (ticketSubtotal !== null && ticketSubtotal !== undefined ? 2 : undefined)
+  const taxAmount =
+    preview?.totals.tax_amount ??
+    (ticketSubtotal !== null && ticketSubtotal !== undefined && convenienceFee !== undefined
+      ? Number(((ticketSubtotal + convenienceFee) * 0.08).toFixed(2))
+      : undefined)
+  const estimatedTotal =
+    ticketSubtotal !== null && ticketSubtotal !== undefined && convenienceFee !== undefined && taxAmount !== undefined
+      ? Number((ticketSubtotal + convenienceFee + taxAmount).toFixed(2))
+      : undefined
+  const formattedTicketSubtotal =
+    ticketSubtotal !== null && ticketSubtotal !== undefined ? `$${ticketSubtotal.toFixed(2)}` : "—"
+  const formattedTotal =
+    totalDue !== undefined
+      ? `$${totalDue.toFixed(2)}`
+      : estimatedTotal !== undefined
+        ? `$${estimatedTotal.toFixed(2)}`
+        : "—"
+  const timerMinutes = String(Math.floor(timerSeconds / 60)).padStart(2, "0")
+  const timerRemainderSeconds = String(timerSeconds % 60).padStart(2, "0")
 
   return (
     <main className="min-h-screen bg-background px-4 py-8 text-white lg:px-8">
@@ -178,18 +254,15 @@ export default function PaymentPage() {
               <button
                 type="button"
                 onClick={handlePay}
-                disabled={submitting}
-                className="mt-2 w-full rounded-xl bg-primary px-6 py-3.5 font-bold text-white transition hover:brightness-110"
+                disabled={submitting || previewLoading}
+                className="mt-2 w-full rounded-xl bg-primary px-6 py-3.5 font-bold text-white transition hover:brightness-110 disabled:opacity-60"
               >
-                {submitting ? "Submitting..." : "Pay $36.40 Securely"}
+                {submitting ? "Processing..." : `Pay ${formattedTotal} Securely`}
               </button>
 
               {submitError && <p className="text-sm text-red-400">{submitError}</p>}
               {successMessage && <p className="text-sm text-green-400">{successMessage}</p>}
-
-              <p className="text-center text-xs text-neutral-500">
-                This build posts to a frontend mock endpoint only. Backend booking API is not called.
-              </p>
+              {previewError && <p className="text-sm text-yellow-400">{previewError}</p>}
 
               <p className="text-center text-xs text-neutral-500">
                 Your transaction is secured with 256-bit SSL encryption.
@@ -204,7 +277,7 @@ export default function PaymentPage() {
               <span className="material-symbols-outlined text-base">timer</span>
               Complete your payment in
             </div>
-            <span className="font-mono text-lg font-bold">09:59</span>
+            <span className="font-mono text-lg font-bold">{timerMinutes}:{timerRemainderSeconds}</span>
           </div>
 
           <div className="overflow-hidden rounded-2xl border border-neutral-800 bg-surface-dark shadow-2xl">
@@ -212,20 +285,22 @@ export default function PaymentPage() {
 
             <div className="space-y-5 p-6">
               <div>
-                <h3 className="text-2xl font-bold">Dune: Part Two</h3>
-                <p className="text-sm text-neutral-500">PG-13 · 2h 46m</p>
+                <h3 className="text-2xl font-bold">{showtimeInfo?.movie_title ?? "—"}</h3>
+                <p className="text-sm text-neutral-500">
+                  {showtimeInfo ? `${showtimeInfo.format} · ${showtimeInfo.language}` : "Loading..."}
+                </p>
               </div>
 
               <div className="grid grid-cols-2 gap-4 text-sm">
                 <div>
                   <p className="text-xs uppercase tracking-wide text-neutral-500">Theater</p>
-                  <p className="font-medium">Grand Cinema</p>
-                  <p className="text-xs text-neutral-500">Hall 4, IMAX 3D</p>
+                  <p className="font-medium">{showtimeInfo?.theater_name ?? "—"}</p>
+                  <p className="text-xs text-neutral-500">{showtimeInfo?.screen_name ?? "—"}</p>
                 </div>
                 <div>
                   <p className="text-xs uppercase tracking-wide text-neutral-500">Date & Time</p>
-                  <p className="font-medium">Sat, 24 Feb</p>
-                  <p className="text-xs text-neutral-500">19:30 PM</p>
+                  <p className="font-medium">{showtimeInfo?.show_date ?? "—"}</p>
+                  <p className="text-xs text-neutral-500">{showtimeInfo?.start_time ?? "—"}</p>
                 </div>
               </div>
 
@@ -250,39 +325,50 @@ export default function PaymentPage() {
                 <p className="mt-1 text-sm font-medium">{showtimeId || "N/A"}</p>
               </div>
 
-              <div>
-                <p className="text-xs uppercase tracking-wide text-neutral-500">Seat IDs (Backend)</p>
-                <p className="mt-1 break-all text-xs text-neutral-500">
-                  {selectedSeatDbIds.length > 0 ? selectedSeatDbIds.join(", ") : "N/A"}
-                </p>
-              </div>
-
               <div className="space-y-2 border-t border-neutral-800 pt-4 text-sm">
-                <div className="flex justify-between text-neutral-500">
-                  <span>Ticket Price (2x)</span>
-                  <span>$32.00</span>
-                </div>
-                <div className="flex justify-between text-neutral-500">
-                  <span>Convenience Fee</span>
-                  <span>$2.50</span>
-                </div>
-                <div className="flex justify-between text-neutral-500">
-                  <span>Tax</span>
-                  <span>$1.90</span>
-                </div>
-                <div className="mt-3 flex justify-between text-lg font-bold">
-                  <span>Total Amount</span>
-                  <span className="text-primary">$36.40</span>
-                </div>
+                {previewLoading ? (
+                  <p className="text-center text-xs text-neutral-500">Loading pricing...</p>
+                ) : (
+                  <>
+                    <div className="flex justify-between text-neutral-500">
+                      <span>Ticket Price ({preview?.line_items.length ?? selectedSeatDbIds.length}x)</span>
+                      <span>{formattedTicketSubtotal}</span>
+                    </div>
+                    <div className="flex justify-between text-neutral-500">
+                      <span>Convenience Fee</span>
+                      <span>{convenienceFee !== undefined ? `$${convenienceFee.toFixed(2)}` : "—"}</span>
+                    </div>
+                    <div className="flex justify-between text-neutral-500">
+                      <span>Tax</span>
+                      <span>{taxAmount !== undefined ? `$${taxAmount.toFixed(2)}` : "—"}</span>
+                    </div>
+                    {preview && preview.totals.discount_amount > 0 && (
+                      <div className="flex justify-between text-green-400">
+                        <span>Discount ({preview.totals.discount_code})</span>
+                        <span>-${preview.totals.discount_amount.toFixed(2)}</span>
+                      </div>
+                    )}
+                    <div className="mt-3 flex justify-between text-lg font-bold">
+                      <span>Total Amount</span>
+                      <span className="text-primary">{formattedTotal}</span>
+                    </div>
+                  </>
+                )}
               </div>
 
               <div className="flex gap-2">
                 <input
                   type="text"
                   placeholder="Have a promo code?"
+                  value={discountCode}
+                  onChange={(e) => setDiscountCode(e.target.value)}
                   className="w-full rounded-lg border border-neutral-800 bg-neutral-900 px-3 py-2 text-sm placeholder:text-neutral-500 focus:border-primary focus:outline-none"
                 />
-                <button type="button" className="rounded-lg border border-neutral-700 px-3 py-2 text-xs font-semibold">
+                <button
+                  type="button"
+                  onClick={handleApplyDiscount}
+                  className="rounded-lg border border-neutral-700 px-3 py-2 text-xs font-semibold"
+                >
                   Apply
                 </button>
               </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3,6 +3,8 @@
 
 import {
   AuthSuccessResponse,
+  CheckoutConfirmResponse,
+  CheckoutQuote,
   Location,
   LoginPayload,
   Movie,
@@ -105,5 +107,30 @@ export async function fetchMovieShowtimes(
 export async function fetchShowtimeSeats(showtimeId: number): Promise<SeatsResponse> {
   const response = await fetch(`${API_BASE_URL}/api/v1/seats?showtime_id=${showtimeId}`)
   return parseResponse<SeatsResponse>(response, "Failed to fetch seats")
+}
+
+export interface CheckoutPayload {
+  user_id: number
+  showtime_id: number
+  seat_ids: number[]
+  discount_code?: string
+}
+
+export async function previewCheckout(payload: CheckoutPayload): Promise<CheckoutQuote> {
+  const response = await fetch(`${API_BASE_URL}/api/v1/checkout/preview`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  })
+  return parseResponse<CheckoutQuote>(response, "Failed to get checkout preview")
+}
+
+export async function confirmCheckout(payload: CheckoutPayload): Promise<CheckoutConfirmResponse> {
+  const response = await fetch(`${API_BASE_URL}/api/v1/checkout/confirm`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  })
+  return parseResponse<CheckoutConfirmResponse>(response, "Failed to confirm booking")
 }
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -102,3 +102,35 @@ export interface SeatsResponse {
   seats: SeatAPI[]
 }
 
+export interface CheckoutLineItem {
+  seat_id: number
+  row_label: string
+  col_number: number
+  seat_type: string
+  unit_price: number
+}
+
+export interface CheckoutTotals {
+  subtotal: number
+  convenience_fee: number
+  tax_amount: number
+  discount_code?: string
+  discount_amount: number
+  total_due: number
+}
+
+export interface CheckoutQuote {
+  showtime_id: number
+  user_id: number
+  line_items: CheckoutLineItem[]
+  totals: CheckoutTotals
+}
+
+export interface CheckoutConfirmResponse {
+  message: string
+  booking_id: number
+  booking_ref: string
+  quote: CheckoutQuote
+  payment_id: number
+}
+


### PR DESCRIPTION
- connect payment page to backend checkout preview and confirm endpoints
- add checkout request/response types and API helpers
- remove backend-only seat IDs from UI
- add pricing fallback from seats API when preview is unavailable
- start checkout countdown timer on page load