### PR TITLE
feat: add user booking history API with tests

### DIFF
--- a/backend/handlers/bookings.go
+++ b/backend/handlers/bookings.go
@@ -1,0 +1,110 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/parasmittal099/backend-project/database"
+	"github.com/parasmittal099/backend-project/models"
+)
+
+type bookingSeatHistory struct {
+	SeatID    uint    `json:"seat_id"`
+	RowLabel  string  `json:"row_label"`
+	ColNumber int     `json:"col_number"`
+	SeatType  string  `json:"seat_type"`
+	SeatPrice float64 `json:"seat_price"`
+}
+
+type bookingHistoryItem struct {
+	ID             uint                 `json:"id"`
+	BookingRef     string               `json:"booking_ref"`
+	Status         string               `json:"status"`
+	TotalAmount    float64              `json:"total_amount"`
+	ConvenienceFee float64              `json:"convenience_fee"`
+	TaxAmount      float64              `json:"tax_amount"`
+	PaymentStatus  string               `json:"payment_status"`
+	BookedAt       string               `json:"booked_at"`
+	MovieTitle     string               `json:"movie_title"`
+	MoviePoster    string               `json:"movie_poster"`
+	TheaterName    string               `json:"theater_name"`
+	ScreenName     string               `json:"screen_name"`
+	ScreenType     string               `json:"screen_type"`
+	ShowDate       string               `json:"show_date"`
+	StartTime      string               `json:"start_time"`
+	Format         string               `json:"format"`
+	Language       string               `json:"language"`
+	Seats          []bookingSeatHistory `json:"seats"`
+}
+
+// GET /api/v1/bookings?user_id=<id>
+func GetUserBookings(c *gin.Context) {
+	userIDParam := c.Query("user_id")
+	if userIDParam == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "user_id query parameter is required"})
+		return
+	}
+
+	userID, err := strconv.Atoi(userIDParam)
+	if err != nil || userID <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "user_id must be a positive integer"})
+		return
+	}
+
+	var bookings []models.Booking
+	if err := database.DB.
+		Where("user_id = ?", userID).
+		Preload("Showtime.Movie").
+		Preload("Showtime.Screen.Theater").
+		Preload("BookingSeats.Seat").
+		Order("booked_at DESC").
+		Find(&bookings).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch bookings"})
+		return
+	}
+
+	respBookings := make([]bookingHistoryItem, 0, len(bookings))
+	for _, b := range bookings {
+		item := bookingHistoryItem{
+			ID:             b.ID,
+			BookingRef:     b.BookingRef,
+			Status:         b.Status,
+			TotalAmount:    b.TotalAmount,
+			ConvenienceFee: b.ConvenienceFee,
+			TaxAmount:      b.TaxAmount,
+			PaymentStatus:  b.PaymentStatus,
+			BookedAt:       b.BookedAt.UTC().Format("2006-01-02T15:04:05Z"),
+			ShowDate:       b.Showtime.ShowDate,
+			StartTime:      b.Showtime.StartTime,
+			Format:         b.Showtime.Format,
+			Language:       b.Showtime.Language,
+		}
+
+		if b.Showtime.Movie.Title != "" {
+			item.MovieTitle = b.Showtime.Movie.Title
+		}
+		if b.Showtime.Movie.PosterURL != nil {
+			item.MoviePoster = *b.Showtime.Movie.PosterURL
+		}
+		item.ScreenName = b.Showtime.Screen.Name
+		item.ScreenType = b.Showtime.Screen.ScreenType
+		item.TheaterName = b.Showtime.Screen.Theater.Name
+
+		seats := make([]bookingSeatHistory, 0, len(b.BookingSeats))
+		for _, bs := range b.BookingSeats {
+			seats = append(seats, bookingSeatHistory{
+				SeatID:    bs.SeatID,
+				RowLabel:  bs.Seat.RowLabel,
+				ColNumber: bs.Seat.ColNumber,
+				SeatType:  bs.Seat.SeatType,
+				SeatPrice: bs.SeatPrice,
+			})
+		}
+		item.Seats = seats
+		respBookings = append(respBookings, item)
+	}
+
+	c.JSON(http.StatusOK, gin.H{"bookings": respBookings})
+}
+

--- a/backend/handlers/bookings_test.go
+++ b/backend/handlers/bookings_test.go
@@ -1,0 +1,206 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/parasmittal099/backend-project/database"
+	"github.com/parasmittal099/backend-project/models"
+	"github.com/parasmittal099/backend-project/testutil"
+)
+
+func setupBookingsRouter() *gin.Engine {
+	r := gin.New()
+	r.GET("/bookings", GetUserBookings)
+	return r
+}
+
+func strPtrBookings(s string) *string { return &s }
+
+func seedBookingHistoryData(t *testing.T) (models.User, models.User, []models.Booking) {
+	t.Helper()
+
+	user1 := models.User{Email: "u1@test.com", Username: "u1", Password: "hash", FullName: "User One"}
+	user2 := models.User{Email: "u2@test.com", Username: "u2", Password: "hash", FullName: "User Two"}
+	database.DB.Create(&user1)
+	database.DB.Create(&user2)
+
+	loc := models.Location{Zipcode: "33101", City: "Miami", State: "FL"}
+	database.DB.Create(&loc)
+
+	addr := "123 Main St"
+	theater := models.Theater{Name: "AMC Miami", LocationID: loc.ID, Address: &addr, TotalScreens: 1}
+	database.DB.Create(&theater)
+
+	screen := models.Screen{TheaterID: theater.ID, Name: "Screen 1", TotalRows: 5, TotalCols: 10, ScreenType: "IMAX"}
+	database.DB.Create(&screen)
+
+	movie := models.Movie{Title: "Demo Movie", PosterURL: strPtrBookings("https://img.test/poster.jpg"), Language: "English", DurationMin: 120, IsActive: true}
+	database.DB.Create(&movie)
+
+	st := models.Showtime{
+		MovieID: movie.ID, ScreenID: screen.ID,
+		ShowDate: "2026-06-15", StartTime: "19:30", EndTime: "21:30",
+		Language: "English", Format: "IMAX", PriceMultiplier: 1.0, IsActive: true,
+	}
+	database.DB.Create(&st)
+
+	seat1 := models.Seat{ScreenID: screen.ID, RowLabel: "G", ColNumber: 12, SeatType: "Premium", BasePrice: 17}
+	seat2 := models.Seat{ScreenID: screen.ID, RowLabel: "G", ColNumber: 13, SeatType: "Premium", BasePrice: 17}
+	seat3 := models.Seat{ScreenID: screen.ID, RowLabel: "G", ColNumber: 14, SeatType: "Premium", BasePrice: 17}
+	database.DB.Create(&seat1)
+	database.DB.Create(&seat2)
+	database.DB.Create(&seat3)
+
+	oldBookedAt := time.Now().Add(-2 * time.Hour)
+	newBookedAt := time.Now().Add(-1 * time.Hour)
+	b1 := models.Booking{
+		UserID: user1.ID, ShowtimeID: st.ID, BookingRef: "G4M-old", Status: "CONFIRMED",
+		TotalAmount: 19, ConvenienceFee: 2, TaxAmount: 0, PaymentStatus: "PAID", BookedAt: oldBookedAt,
+	}
+	b2 := models.Booking{
+		UserID: user1.ID, ShowtimeID: st.ID, BookingRef: "G4M-new", Status: "CONFIRMED",
+		TotalAmount: 34, ConvenienceFee: 2, TaxAmount: 2.88, PaymentStatus: "PAID", BookedAt: newBookedAt,
+	}
+	bOther := models.Booking{
+		UserID: user2.ID, ShowtimeID: st.ID, BookingRef: "G4M-other", Status: "CONFIRMED",
+		TotalAmount: 34, ConvenienceFee: 2, TaxAmount: 2.88, PaymentStatus: "PAID", BookedAt: newBookedAt,
+	}
+	database.DB.Create(&b1)
+	database.DB.Create(&b2)
+	database.DB.Create(&bOther)
+
+	database.DB.Create(&models.BookingSeat{BookingID: b1.ID, SeatID: seat3.ID, ShowtimeID: st.ID, SeatPrice: 17})
+	database.DB.Create(&models.BookingSeat{BookingID: b2.ID, SeatID: seat1.ID, ShowtimeID: st.ID, SeatPrice: 17})
+	database.DB.Create(&models.BookingSeat{BookingID: b2.ID, SeatID: seat2.ID, ShowtimeID: st.ID, SeatPrice: 17})
+	database.DB.Create(&models.BookingSeat{BookingID: bOther.ID, SeatID: seat3.ID, ShowtimeID: st.ID, SeatPrice: 17})
+
+	return user1, user2, []models.Booking{b1, b2, bOther}
+}
+
+func TestGetUserBookings_SuccessOrderedAndMapped(t *testing.T) {
+	testutil.SetupTestDB(t)
+	u1, _, _ := seedBookingHistoryData(t)
+	r := setupBookingsRouter()
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/bookings?user_id="+fmtUint(u1.ID), nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	bookings := resp["bookings"].([]any)
+	if len(bookings) != 2 {
+		t.Fatalf("expected 2 bookings for user1, got %d", len(bookings))
+	}
+
+	first := bookings[0].(map[string]any)
+	second := bookings[1].(map[string]any)
+	if first["booking_ref"] != "G4M-new" || second["booking_ref"] != "G4M-old" {
+		t.Fatalf("expected bookings ordered by booked_at desc, got first=%v second=%v", first["booking_ref"], second["booking_ref"])
+	}
+	if first["movie_title"] != "Demo Movie" {
+		t.Fatalf("expected movie_title mapped, got %v", first["movie_title"])
+	}
+	if first["movie_poster"] != "https://img.test/poster.jpg" {
+		t.Fatalf("expected movie_poster mapped, got %v", first["movie_poster"])
+	}
+	if first["theater_name"] != "AMC Miami" || first["screen_name"] != "Screen 1" || first["screen_type"] != "IMAX" {
+		t.Fatalf("expected theater/screen mapping, got theater=%v screen=%v type=%v", first["theater_name"], first["screen_name"], first["screen_type"])
+	}
+	seats := first["seats"].([]any)
+	if len(seats) != 2 {
+		t.Fatalf("expected 2 seats in latest booking, got %d", len(seats))
+	}
+}
+
+func TestGetUserBookings_Empty(t *testing.T) {
+	testutil.SetupTestDB(t)
+	r := setupBookingsRouter()
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/bookings?user_id=9999", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	bookings := resp["bookings"].([]any)
+	if len(bookings) != 0 {
+		t.Fatalf("expected empty bookings array, got %d", len(bookings))
+	}
+}
+
+func TestGetUserBookings_MissingUserID(t *testing.T) {
+	testutil.SetupTestDB(t)
+	r := setupBookingsRouter()
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/bookings", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestGetUserBookings_NonNumericUserID(t *testing.T) {
+	testutil.SetupTestDB(t)
+	r := setupBookingsRouter()
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/bookings?user_id=abc", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestGetUserBookings_InvalidUserID(t *testing.T) {
+	testutil.SetupTestDB(t)
+	r := setupBookingsRouter()
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/bookings?user_id=0", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestGetUserBookings_IsolationByUser(t *testing.T) {
+	testutil.SetupTestDB(t)
+	_, u2, _ := seedBookingHistoryData(t)
+	r := setupBookingsRouter()
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/bookings?user_id="+fmtUint(u2.ID), nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	bookings := resp["bookings"].([]any)
+	if len(bookings) != 1 {
+		t.Fatalf("expected only one booking for user2, got %d", len(bookings))
+	}
+	ref := bookings[0].(map[string]any)["booking_ref"]
+	if ref != "G4M-other" {
+		t.Fatalf("expected G4M-other booking for user2, got %v", ref)
+	}
+}
+
+func fmtUint(v uint) string {
+	return strconv.FormatUint(uint64(v), 10)
+}
+

--- a/backend/routes/routes.go
+++ b/backend/routes/routes.go
@@ -21,6 +21,7 @@ func RegisterRoutes(r *gin.Engine, cfg *config.Config) {
 
 		v1.POST("/checkout/preview", handlers.PreviewCheckout)
 		v1.POST("/checkout/confirm", handlers.ConfirmCheckout)
+		v1.GET("/bookings", handlers.GetUserBookings)
 
 		auth := v1.Group("/auth")
 		{

--- a/backend/routes/routes_test.go
+++ b/backend/routes/routes_test.go
@@ -44,6 +44,7 @@ func TestRegisterRoutes_AllEndpoints(t *testing.T) {
 		{"GET", "/api/v1/movies/:id"},
 		{"GET", "/api/v1/movies/:id/showtimes"},
 		{"GET", "/api/v1/seats"},
+		{"GET", "/api/v1/bookings"},
 		{"POST", "/api/v1/auth/register"},
 		{"POST", "/api/v1/auth/login"},
 		{"POST", "/api/v1/checkout/preview"},
@@ -66,7 +67,7 @@ func TestRegisterRoutes_CountRoutes(t *testing.T) {
 	RegisterRoutes(r, cfg)
 
 	routes := r.Routes()
-	if len(routes) < 9 {
-		t.Errorf("expected at least 9 routes, got %d", len(routes))
+	if len(routes) < 10 {
+		t.Errorf("expected at least 10 routes, got %d", len(routes))
 	}
 }


### PR DESCRIPTION
Implement GET /api/v1/bookings with user_id validation, booking relation preloads, and flattened history response mapping. Add handler and route tests for ordering, validation, empty state, and user isolation.