### PR TITLE
feat: add QR ticket lookup flow for confirmed bookings

### DIFF
--- a/backend/database/database.go
+++ b/backend/database/database.go
@@ -51,6 +51,7 @@ func Migrate() {
         &models.Booking{},
         &models.BookingSeat{},
         &models.Payment{},
+		&models.QRTicket{},
     )
     if err != nil {
         log.Fatalf("Failed to auto-migrate: %v", err)

--- a/backend/handlers/bookings.go
+++ b/backend/handlers/bookings.go
@@ -38,6 +38,46 @@ type bookingHistoryItem struct {
 	Seats          []bookingSeatHistory `json:"seats"`
 }
 
+func mapBookingHistoryItem(b models.Booking) bookingHistoryItem {
+	item := bookingHistoryItem{
+		ID:             b.ID,
+		BookingRef:     b.BookingRef,
+		Status:         b.Status,
+		TotalAmount:    b.TotalAmount,
+		ConvenienceFee: b.ConvenienceFee,
+		TaxAmount:      b.TaxAmount,
+		PaymentStatus:  b.PaymentStatus,
+		BookedAt:       b.BookedAt.UTC().Format("2006-01-02T15:04:05Z"),
+		ShowDate:       b.Showtime.ShowDate,
+		StartTime:      b.Showtime.StartTime,
+		Format:         b.Showtime.Format,
+		Language:       b.Showtime.Language,
+	}
+
+	if b.Showtime.Movie.Title != "" {
+		item.MovieTitle = b.Showtime.Movie.Title
+	}
+	if b.Showtime.Movie.PosterURL != nil {
+		item.MoviePoster = *b.Showtime.Movie.PosterURL
+	}
+	item.ScreenName = b.Showtime.Screen.Name
+	item.ScreenType = b.Showtime.Screen.ScreenType
+	item.TheaterName = b.Showtime.Screen.Theater.Name
+
+	seats := make([]bookingSeatHistory, 0, len(b.BookingSeats))
+	for _, bs := range b.BookingSeats {
+		seats = append(seats, bookingSeatHistory{
+			SeatID:    bs.SeatID,
+			RowLabel:  bs.Seat.RowLabel,
+			ColNumber: bs.Seat.ColNumber,
+			SeatType:  bs.Seat.SeatType,
+			SeatPrice: bs.SeatPrice,
+		})
+	}
+	item.Seats = seats
+	return item
+}
+
 // GET /api/v1/bookings — accepts JWT (user_id from token) or ?user_id= query param
 func GetUserBookings(c *gin.Context) {
 	var userID uint
@@ -69,43 +109,7 @@ func GetUserBookings(c *gin.Context) {
 
 	respBookings := make([]bookingHistoryItem, 0, len(bookings))
 	for _, b := range bookings {
-		item := bookingHistoryItem{
-			ID:             b.ID,
-			BookingRef:     b.BookingRef,
-			Status:         b.Status,
-			TotalAmount:    b.TotalAmount,
-			ConvenienceFee: b.ConvenienceFee,
-			TaxAmount:      b.TaxAmount,
-			PaymentStatus:  b.PaymentStatus,
-			BookedAt:       b.BookedAt.UTC().Format("2006-01-02T15:04:05Z"),
-			ShowDate:       b.Showtime.ShowDate,
-			StartTime:      b.Showtime.StartTime,
-			Format:         b.Showtime.Format,
-			Language:       b.Showtime.Language,
-		}
-
-		if b.Showtime.Movie.Title != "" {
-			item.MovieTitle = b.Showtime.Movie.Title
-		}
-		if b.Showtime.Movie.PosterURL != nil {
-			item.MoviePoster = *b.Showtime.Movie.PosterURL
-		}
-		item.ScreenName = b.Showtime.Screen.Name
-		item.ScreenType = b.Showtime.Screen.ScreenType
-		item.TheaterName = b.Showtime.Screen.Theater.Name
-
-		seats := make([]bookingSeatHistory, 0, len(b.BookingSeats))
-		for _, bs := range b.BookingSeats {
-			seats = append(seats, bookingSeatHistory{
-				SeatID:    bs.SeatID,
-				RowLabel:  bs.Seat.RowLabel,
-				ColNumber: bs.Seat.ColNumber,
-				SeatType:  bs.Seat.SeatType,
-				SeatPrice: bs.SeatPrice,
-			})
-		}
-		item.Seats = seats
-		respBookings = append(respBookings, item)
+		respBookings = append(respBookings, mapBookingHistoryItem(b))
 	}
 
 	c.JSON(http.StatusOK, gin.H{"bookings": respBookings})

--- a/backend/handlers/checkout.go
+++ b/backend/handlers/checkout.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/hex"
 	"errors"
 	"math"
@@ -209,6 +210,45 @@ func newBookingRef() string {
 	return "G4M-" + hex.EncodeToString(b)
 }
 
+func newTicketCode() (string, error) {
+	b := make([]byte, 18)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+func getOrCreateQRTicket(tx *gorm.DB, bookingID uint) (*models.QRTicket, error) {
+	var existing models.QRTicket
+	if err := tx.Where("booking_id = ?", bookingID).First(&existing).Error; err == nil {
+		return &existing, nil
+	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, err
+	}
+
+	for i := 0; i < 5; i++ {
+		code, err := newTicketCode()
+		if err != nil {
+			return nil, err
+		}
+
+		qr := models.QRTicket{
+			BookingID:  bookingID,
+			TicketCode: code,
+			IsActive:   true,
+		}
+		if err := tx.Create(&qr).Error; err != nil {
+			if strings.Contains(err.Error(), "UNIQUE constraint failed: qr_tickets.ticket_code") {
+				continue
+			}
+			return nil, err
+		}
+		return &qr, nil
+	}
+
+	return nil, errors.New("failed to generate unique ticket code")
+}
+
 // POST /api/v1/checkout/confirm (JWT-protected)
 func ConfirmCheckout(c *gin.Context) {
 	var req checkoutRequest
@@ -233,6 +273,7 @@ func ConfirmCheckout(c *gin.Context) {
 
 	var booking models.Booking
 	var payment models.Payment
+	var qrTicket models.QRTicket
 
 	txErr := database.DB.Transaction(func(tx *gorm.DB) error {
 		// Re-check availability inside the transaction (serialised by SQLite's write lock)
@@ -289,6 +330,12 @@ func ConfirmCheckout(c *gin.Context) {
 			return err
 		}
 
+		ticket, err := getOrCreateQRTicket(tx, booking.ID)
+		if err != nil {
+			return err
+		}
+		qrTicket = *ticket
+
 		return nil
 	})
 
@@ -311,5 +358,7 @@ func ConfirmCheckout(c *gin.Context) {
 		"booking_ref": booking.BookingRef,
 		"quote":       quote,
 		"payment_id":  payment.ID,
+		"ticket_code": qrTicket.TicketCode,
+		"qr_value":    "G4M:" + qrTicket.TicketCode,
 	})
 }

--- a/backend/handlers/checkout_test.go
+++ b/backend/handlers/checkout_test.go
@@ -321,11 +321,21 @@ func TestConfirmCheckout_CreatesBookingAndPayment(t *testing.T) {
 	if count != 1 {
 		t.Errorf("want 1 payment, got %d", count)
 	}
+	database.DB.Model(&models.QRTicket{}).Count(&count)
+	if count != 1 {
+		t.Errorf("want 1 qr_ticket, got %d", count)
+	}
 
 	var b models.Booking
 	database.DB.First(&b)
 	if b.Status != "CONFIRMED" || b.PaymentStatus != "PAID" {
 		t.Errorf("booking status want CONFIRMED/PAID, got %s/%s", b.Status, b.PaymentStatus)
+	}
+	if resp["ticket_code"] == nil || resp["ticket_code"] == "" {
+		t.Error("missing ticket_code")
+	}
+	if resp["qr_value"] == nil || resp["qr_value"] == "" {
+		t.Error("missing qr_value")
 	}
 }
 

--- a/backend/handlers/qr.go
+++ b/backend/handlers/qr.go
@@ -1,0 +1,57 @@
+package handlers
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/parasmittal099/backend-project/database"
+	"github.com/parasmittal099/backend-project/models"
+	"gorm.io/gorm"
+)
+
+// GET /api/v1/bookings/by-ticket?ticket_code=<code>
+func GetBookingByTicketCode(c *gin.Context) {
+	ticketCode := strings.TrimSpace(c.Query("ticket_code"))
+	if ticketCode == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "ticket_code query parameter is required"})
+		return
+	}
+
+	var qrTicket models.QRTicket
+	if err := database.DB.Where("ticket_code = ? AND is_active = ?", ticketCode, true).First(&qrTicket).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Ticket not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to resolve ticket"})
+		return
+	}
+
+	if qrTicket.ExpiresAt != nil && qrTicket.ExpiresAt.Before(time.Now()) {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Ticket not found"})
+		return
+	}
+
+	var booking models.Booking
+	if err := database.DB.
+		Where("id = ?", qrTicket.BookingID).
+		Preload("Showtime.Movie").
+		Preload("Showtime.Screen.Theater").
+		Preload("BookingSeats.Seat").
+		First(&booking).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Booking not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch booking"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"booking":     mapBookingHistoryItem(booking),
+		"ticket_code": qrTicket.TicketCode,
+		"qr_value":    "G4M:" + qrTicket.TicketCode,
+	})
+}

--- a/backend/handlers/qr_test.go
+++ b/backend/handlers/qr_test.go
@@ -1,0 +1,80 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/parasmittal099/backend-project/database"
+	"github.com/parasmittal099/backend-project/models"
+	"github.com/parasmittal099/backend-project/testutil"
+)
+
+func setupQRRouter() *gin.Engine {
+	r := gin.New()
+	r.GET("/bookings/by-ticket", GetBookingByTicketCode)
+	return r
+}
+
+func TestGetBookingByTicketCode_Success(t *testing.T) {
+	testutil.SetupTestDB(t)
+	_, _, bookings := seedBookingHistoryData(t)
+	target := bookings[1] // G4M-new
+
+	qr := models.QRTicket{
+		BookingID:  target.ID,
+		TicketCode: "ticket-abc-123",
+		IsActive:   true,
+	}
+	if err := database.DB.Create(&qr).Error; err != nil {
+		t.Fatalf("create qr ticket: %v", err)
+	}
+
+	r := setupQRRouter()
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/bookings/by-ticket?ticket_code=ticket-abc-123", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["ticket_code"] != "ticket-abc-123" {
+		t.Fatalf("expected ticket_code in response, got %v", resp["ticket_code"])
+	}
+
+	booking := resp["booking"].(map[string]any)
+	if booking["booking_ref"] != "G4M-new" {
+		t.Fatalf("expected booking_ref G4M-new, got %v", booking["booking_ref"])
+	}
+}
+
+func TestGetBookingByTicketCode_MissingCode(t *testing.T) {
+	testutil.SetupTestDB(t)
+	r := setupQRRouter()
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/bookings/by-ticket", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetBookingByTicketCode_NotFound(t *testing.T) {
+	testutil.SetupTestDB(t)
+	r := setupQRRouter()
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/bookings/by-ticket?ticket_code=missing-code", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/backend/models/booking_test.go
+++ b/backend/models/booking_test.go
@@ -128,3 +128,33 @@ func TestPayment_Create(t *testing.T) {
 		t.Error("expected non-zero ID")
 	}
 }
+
+func TestQRTicket_UniqueTicketCode(t *testing.T) {
+	db := setupModelsDB(t)
+	user, st, _ := seedBookingData(t, db)
+
+	booking1 := Booking{UserID: user.ID, ShowtimeID: st.ID, BookingRef: "QR-REF-1", Status: "CONFIRMED", TotalAmount: 18.0, PaymentStatus: "PAID", BookedAt: time.Now()}
+	booking2 := Booking{UserID: user.ID, ShowtimeID: st.ID, BookingRef: "QR-REF-2", Status: "CONFIRMED", TotalAmount: 18.0, PaymentStatus: "PAID", BookedAt: time.Now()}
+	db.Create(&booking1)
+	db.Create(&booking2)
+
+	db.Create(&QRTicket{BookingID: booking1.ID, TicketCode: "same-code"})
+	err := db.Create(&QRTicket{BookingID: booking2.ID, TicketCode: "same-code"}).Error
+	if err == nil {
+		t.Error("expected unique constraint violation on ticket_code")
+	}
+}
+
+func TestQRTicket_OnePerBooking(t *testing.T) {
+	db := setupModelsDB(t)
+	user, st, _ := seedBookingData(t, db)
+
+	booking := Booking{UserID: user.ID, ShowtimeID: st.ID, BookingRef: "QR-ONE-BOOKING", Status: "CONFIRMED", TotalAmount: 18.0, PaymentStatus: "PAID", BookedAt: time.Now()}
+	db.Create(&booking)
+
+	db.Create(&QRTicket{BookingID: booking.ID, TicketCode: "code-1"})
+	err := db.Create(&QRTicket{BookingID: booking.ID, TicketCode: "code-2"}).Error
+	if err == nil {
+		t.Error("expected unique constraint violation on booking_id")
+	}
+}

--- a/backend/models/qr_ticket.go
+++ b/backend/models/qr_ticket.go
@@ -1,0 +1,14 @@
+package models
+
+import "time"
+
+type QRTicket struct {
+	ID         uint       `gorm:"primaryKey" json:"id"`
+	BookingID  uint       `gorm:"uniqueIndex;not null" json:"booking_id"`
+	Booking    Booking    `gorm:"foreignKey:BookingID;constraint:OnDelete:CASCADE" json:"-"`
+	TicketCode string     `gorm:"uniqueIndex;not null" json:"ticket_code"`
+	IsActive   bool       `gorm:"not null;default:true" json:"is_active"`
+	ExpiresAt  *time.Time `gorm:"index" json:"expires_at,omitempty"`
+	CreatedAt  time.Time  `json:"created_at"`
+	UpdatedAt  time.Time  `json:"updated_at"`
+}

--- a/backend/models/user_test.go
+++ b/backend/models/user_test.go
@@ -16,7 +16,7 @@ func setupModelsDB(t *testing.T) *gorm.DB {
 	if err != nil {
 		t.Fatalf("failed to open test db: %v", err)
 	}
-	db.AutoMigrate(&User{}, &Location{}, &Movie{}, &Theater{}, &Screen{}, &Seat{}, &Showtime{}, &Booking{}, &BookingSeat{}, &Payment{})
+	db.AutoMigrate(&User{}, &Location{}, &Movie{}, &Theater{}, &Screen{}, &Seat{}, &Showtime{}, &Booking{}, &BookingSeat{}, &Payment{}, &QRTicket{})
 	sqlDB, _ := db.DB()
 	sqlDB.Exec("PRAGMA foreign_keys = ON")
 	return db

--- a/backend/routes/routes.go
+++ b/backend/routes/routes.go
@@ -21,6 +21,7 @@ func RegisterRoutes(r *gin.Engine, cfg *config.Config) {
 		v1.POST("/checkout/preview", handlers.PreviewCheckout)
 		v1.POST("/checkout/confirm", middleware.OptionalJWTAuth(cfg.JWTSecret), handlers.ConfirmCheckout)
 		v1.GET("/bookings", middleware.OptionalJWTAuth(cfg.JWTSecret), handlers.GetUserBookings)
+		v1.GET("/bookings/by-ticket", handlers.GetBookingByTicketCode)
 
 		auth := v1.Group("/auth")
 		{

--- a/backend/routes/routes_test.go
+++ b/backend/routes/routes_test.go
@@ -45,6 +45,7 @@ func TestRegisterRoutes_AllEndpoints(t *testing.T) {
 		{"GET", "/api/v1/movies/:id/showtimes"},
 		{"GET", "/api/v1/seats"},
 		{"GET", "/api/v1/bookings"},
+		{"GET", "/api/v1/bookings/by-ticket"},
 		{"POST", "/api/v1/auth/register"},
 		{"POST", "/api/v1/auth/login"},
 		{"POST", "/api/v1/checkout/preview"},
@@ -67,7 +68,7 @@ func TestRegisterRoutes_CountRoutes(t *testing.T) {
 	RegisterRoutes(r, cfg)
 
 	routes := r.Routes()
-	if len(routes) < 10 {
-		t.Errorf("expected at least 10 routes, got %d", len(routes))
+	if len(routes) < 11 {
+		t.Errorf("expected at least 11 routes, got %d", len(routes))
 	}
 }

--- a/backend/testutil/testutil.go
+++ b/backend/testutil/testutil.go
@@ -41,6 +41,7 @@ func SetupTestDB(t *testing.T) *gorm.DB {
 		&models.Booking{},
 		&models.BookingSeat{},
 		&models.Payment{},
+		&models.QRTicket{},
 	)
 	if err != nil {
 		t.Fatalf("failed to migrate test database: %v", err)


### PR DESCRIPTION
Generate and persist random ticket codes during checkout confirmation, expose booking lookup by ticket code, and add migration and test coverage for QR ticket constraints and routes.

Added a secure QR ticket flow end-to-end:

Created QRTicket mapping table (ticket_code -> booking_id) with unique constraints.
On checkout/confirm, backend now generates/stores a secure random ticket_code and returns ticket_code + qr_value.
Added read-only scan API: GET /api/v1/bookings/by-ticket?ticket_code=... to fetch booking details.
Registered the new route and reused booking response mapping for consistent payloads.
Added handler/model/route tests for QR scenarios and constraints.
Ran go test ./... successfully.