### PR TITLE
fix: auto-install frontend dependencies at container startup

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -16,5 +16,5 @@ COPY . .
 # Next.js default dev port
 EXPOSE 3000
 
-# Run the app in development mode
-CMD ["npm", "run", "dev"]
+# Run install on container start, then launch dev server
+CMD ["sh", "-c", "npm install && npm run dev"]


### PR DESCRIPTION
Run npm install before starting Next.js dev server so stale Docker node_modules volumes do not miss newly added packages.

